### PR TITLE
Update `setLevelName()` to Use `sub-motd` and Update Main `motd` for Server Tab Display

### DIFF
--- a/Allay-API/src/main/java/org/allaymc/api/server/ServerSettings.java
+++ b/Allay-API/src/main/java/org/allaymc/api/server/ServerSettings.java
@@ -33,7 +33,7 @@ public class ServerSettings extends OkaeriConfig {
     @Accessors(fluent = true)
     public static class GenericSettings extends OkaeriConfig {
 
-        private String motd = "An allay-powered server";
+        private String motd = "§bAllayMc Server";
 
         @CustomKey("sub-motd")
         @Comment("Usually only visible on the LAN interface")

--- a/Allay-Server/src/main/java/org/allaymc/server/entity/component/player/EntityPlayerNetworkComponentImpl.java
+++ b/Allay-Server/src/main/java/org/allaymc/server/entity/component/player/EntityPlayerNetworkComponentImpl.java
@@ -321,7 +321,7 @@ public class EntityPlayerNetworkComponentImpl implements EntityPlayerNetworkComp
         startGamePacket.setDifficulty(spawnWorld.getWorldData().getDifficulty().ordinal());
         // TODO: add it to server-settings.yml
         startGamePacket.setTrustingPlayers(true);
-        startGamePacket.setLevelName(Server.SETTINGS.genericSettings().motd());
+        startGamePacket.setLevelName(Server.SETTINGS.genericSettings().subMotd());
         startGamePacket.setLevelId("");
         startGamePacket.setDefaultPlayerPermission(Server.SETTINGS.genericSettings().defaultPermission());
         startGamePacket.setServerChunkTickRange(spawnWorld.getWorldData().getServerChunkTickRange());


### PR DESCRIPTION
1. **Integration of `sub-motd` in `setLevelName()`:** 
   - The `setLevelName()` function has been updated to utilize the `sub-motd`. This ensures that the correct sub-message of the day is applied wherever the function is used.

2. **Modification of the `motd`:**
   - The main `motd` (name server) has been adjusted. This change ensures that when players view the server in the Minecraft tab, the displayed message accurately reflects the intended message. Previously, only a truncated version ("An...") was visible, which could cause confusion or not fully convey the server's message.

These updates enhance the clarity and consistency of the information displayed in the Minecraft server tab, improving the overall user experience.

## Testing
- Verified that `setLevelName()` correctly displays the `sub-motd`.
- Confirmed that the new `motd` is fully visible in the server tab without truncation.