### PR TITLE
build: Update shadow plugin

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -74,6 +74,6 @@ graalvm = ["sdk", "js", "polyglot", "chromeinspector-tool", "profiler-tool"]
 junit = ["junit-jupiter", "mockito-junit-jupiter"]
 
 [plugins]
-shadow = { id = "com.github.johnrengelman.shadow", version = "8.1.1" }
+shadow = { id = "com.gradleup.shadow", version = "8.3.1" }
 gitproperties = { id = "com.gorylenko.gradle-git-properties", version = "2.4.2" }
 jmh = { id = "me.champeau.jmh", version = "0.7.2" }


### PR DESCRIPTION
https://github.com/GradleUp/shadow/releases/tag/8.3.0

> We also update the plugin ID from `com.github.johnrengelman.shadow` to `com.gradleup.shadow`, and the
Maven coordinate from `com.github.johnrengelman:shadow` to `com.gradleup.shadow:shadow-gradle-plugin`.