### PR TITLE
fix: Door-related bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Unless otherwise specified, any version comparison below is the comparison of se
 - Fixed visual flashes when eating chorus fruits.
 - Fixed incorrect comparison of `Position3x#dimension`.
 - Fixed a number of falling block related bugs.
+- Fixed incorrectly dropping drops when destroying the upper part of a door in creation mode.
 
 ## [0.1.0](https://github.com/AllayMC/Allay/releases/tag/0.1.0) (API 0.1.0) - 2024-12-22
 

--- a/server/src/main/java/org/allaymc/server/block/component/door/BlockDoorBaseComponentImpl.java
+++ b/server/src/main/java/org/allaymc/server/block/component/door/BlockDoorBaseComponentImpl.java
@@ -124,6 +124,14 @@ public class BlockDoorBaseComponentImpl extends BlockBaseComponentImpl {
     }
 
     @Override
+    public void onBreak(BlockStateWithPos blockState, ItemStack usedItem, Entity entity) {
+        if(blockState.blockState().getPropertyValue(UPPER_BLOCK_BIT)){
+            blockState.pos().dimension().breakBlock(((Vector3i) blockState.pos()).sub(0,1,0),null, entity);
+        }
+        super.onBreak(blockState, usedItem, entity);
+    }
+
+    @Override
     public Set<ItemStack> getDrops(BlockStateWithPos blockState, ItemStack usedItem, Entity entity) {
         return blockState.blockState().getPropertyValue(UPPER_BLOCK_BIT) ? Utils.EMPTY_ITEM_STACK_SET : super.getDrops(blockState, usedItem, entity);
     }

--- a/server/src/main/java/org/allaymc/server/block/component/door/BlockDoorBaseComponentImpl.java
+++ b/server/src/main/java/org/allaymc/server/block/component/door/BlockDoorBaseComponentImpl.java
@@ -125,8 +125,8 @@ public class BlockDoorBaseComponentImpl extends BlockBaseComponentImpl {
 
     @Override
     public void onBreak(BlockStateWithPos blockState, ItemStack usedItem, Entity entity) {
-        if(blockState.blockState().getPropertyValue(UPPER_BLOCK_BIT)){
-            blockState.pos().dimension().breakBlock(((Vector3i) blockState.pos()).sub(0,1,0),null, entity);
+        if (blockState.blockState().getPropertyValue(UPPER_BLOCK_BIT)) {
+            blockState.pos().dimension().breakBlock(((Vector3i) blockState.pos()).sub(0, 1, 0), null, entity);
         }
         super.onBreak(blockState, usedItem, entity);
     }


### PR DESCRIPTION
Incorrectly dropping drops when destroying the upper part of a door in creation mode