### PR TITLE
refactor: public server connection by default

### DIFF
--- a/api/src/main/java/org/allaymc/api/server/ServerSettings.java
+++ b/api/src/main/java/org/allaymc/api/server/ServerSettings.java
@@ -95,7 +95,7 @@ public class ServerSettings extends OkaeriConfig {
     @Getter
     @Accessors(fluent = true)
     public static class NetworkSettings extends OkaeriConfig {
-        private String ip = "127.0.0.1";
+        private String ip = "0.0.0.0";
 
         private int port = 19132;
 


### PR DESCRIPTION
Yes, bind to `127.0.0.1` means you can only connect your server in local. But most of servers is public to other players...