### PR TITLE
feat: improve fill command logic

### DIFF
--- a/server/src/main/java/org/allaymc/server/command/defaults/FillCommand.java
+++ b/server/src/main/java/org/allaymc/server/command/defaults/FillCommand.java
@@ -27,7 +27,7 @@ public class FillCommand extends SimpleCommand {
                 .optional()
                 .exec(context -> {
                     var from = context.<Vector3d>getResult(0).floor();
-                    var to = context.<Vector3d>getResult(1).ceil();
+                    var to = context.<Vector3d>getResult(1).floor();
                     var dim = context.getSender().getCmdExecuteLocation().dimension();
                     if (!dim.isInWorld(from.x(), from.y(), from.z()) || !dim.isInWorld(to.x(), to.y(), to.z())) {
                         context.addError("%" + TrKeys.M_COMMANDS_FILL_OUTOFWORLD);
@@ -43,15 +43,22 @@ public class FillCommand extends SimpleCommand {
                         return context.fail();
                     }
 
-                    var count = 0;
-                    for (var x = from.x; x <= to.x; x++) {
-                        for (var y = from.y; y <= to.y; y++) {
-                            for (var z = from.z; z <= to.z; z++) {
+                    var minX = Math.min(from.x, to.x);
+                    var maxX = Math.max(from.x, to.x);
+                    var minY = Math.min(from.y, to.y);
+                    var maxY = Math.max(from.y, to.y);
+                    var minZ = Math.min(from.z, to.z);
+                    var maxZ = Math.max(from.z, to.z);
+
+                    for (var x = minX; x <= maxX; x++) {
+                        for (var y = minY; y <= maxY; y++) {
+                            for (var z = minZ; z <= maxZ; z++) {
                                 dim.setBlockState(x, y, z, blockState);
                                 count++;
                             }
                         }
                     }
+
                     context.addOutput(TrKeys.M_COMMANDS_FILL_SUCCESS, count);
 
                     return context.success();


### PR DESCRIPTION
Currently, there are two notable issues with the implementation of the fill command:

1. The main for-loop does not verify actual min and max values, leading to undesired behaviour when the user specifies the first coordinates as larger than the second ones: the loop body is not executed, and no blocks are filled. For example, `fill 0 0 0 10 10 10 block` fills all the blocks, whereas `fill 10 10 10 0 0 0 block` does not. This can be resolved with simple min/max checks.
https://github.com/AllayMC/Allay/blob/cab77f6232d95666a4304fac31b82ce671d10012/server/src/main/java/org/allaymc/server/command/defaults/FillCommand.java#L47-L54
2. Ceiling the second coordinate causes undesired behaviour with floating-point inputs (e.g. filled by auto completion) and tildes (player's current position). For example, `fill 0.5 0.5 0.5 0.5 0.5 0.5 block` (or `fill ~ ~ ~ ~ ~ ~ block`) is converted to `from = (0, 0, 0)` due to floor, and `to = (1, 1, 1)` due to ceil, resulting in 4×4 blocks being filled instead of 1. On the other hand, flooring the "to" coordinates would only fill the single block at (0, 0, 0).
https://github.com/AllayMC/Allay/blob/cab77f6232d95666a4304fac31b82ce671d10012/server/src/main/java/org/allaymc/server/command/defaults/FillCommand.java#L29-L30

Both issues are fixed in my PR, and I believe it would make fill command more intuitive and match vanilla behaviour.