### PR TITLE
feat: add equals and hashCode to effect type

### DIFF
--- a/api/src/main/java/org/allaymc/api/entity/effect/AbstractEffectType.java
+++ b/api/src/main/java/org/allaymc/api/entity/effect/AbstractEffectType.java
@@ -30,4 +30,18 @@ public abstract class AbstractEffectType implements EffectType {
     public EffectInstance createInstance(int amplifier, int duration, boolean ambient, boolean visible) {
         return new EffectInstance(this, amplifier, duration, ambient, visible);
     }
+
+    @Override 
+    public boolean equals(Object other) {
+        if (other instanceof AbstractEffectType effect) {
+            return id == effect.id;
+        } else {
+            return false;
+        }
+    }
+    
+    @Override 
+    public int hashCode() {
+        return id;
+    }
 }


### PR DESCRIPTION
I think there is an issue with the current EffectType implementation.

Given the following methods:
https://github.com/AllayMC/Allay/blob/1066011a0527d3aae84d0cad05c5f9e5e26ba913/api/src/main/java/org/allaymc/api/entity/component/EntityBaseComponent.java#L566-L580

Used as:
```
player.addEffect(EffectInstance(EffectBlindnessType(), 255, Int.MaxValue, false, false))
player.removeEffect(EffectBlindnessType())
```

The blindness effect would be added but not removed. This happens because effects are stored in a `Map<EffectType, EffectInstance>`, yet EffectType implementors do not override equals and hashCode. As a result, the lookup fails and removeEffect returns early:
https://github.com/AllayMC/Allay/blob/1066011a0527d3aae84d0cad05c5f9e5e26ba913/server/src/main/java/org/allaymc/server/entity/component/EntityBaseComponentImpl.java#L810-L812

Seems like there are no singleton instances of EffectTypes for reference equality to work and all constructors are public, so the most obvious fix is to implement equals and hashCode in the common parent class -- AbstractEffectType -- using the unique effect id.