### PR TITLE
feat: allow specify custom cancel/revert position for PlayerMoveEvent

### DIFF
--- a/api/src/main/java/org/allaymc/api/eventbus/event/player/PlayerMoveEvent.java
+++ b/api/src/main/java/org/allaymc/api/eventbus/event/player/PlayerMoveEvent.java
@@ -1,6 +1,7 @@
 package org.allaymc.api.eventbus.event.player;
 
 import lombok.Getter;
+import lombok.Setter;
 import org.allaymc.api.entity.interfaces.EntityPlayer;
 import org.allaymc.api.eventbus.event.CancellableEvent;
 import org.allaymc.api.math.location.Location3dc;
@@ -12,6 +13,14 @@ import org.allaymc.api.math.location.Location3dc;
 public class PlayerMoveEvent extends PlayerEvent implements CancellableEvent {
     protected Location3dc from;
     protected Location3dc to;
+
+    /**
+     * If event is cancelled, player get teleported to specified location, which is defaults to original one.
+     *
+     * If set to null, no teleport would be issued; it up to user to handle client-server movement desync.
+     */ 
+    @Setter
+    protected Location3dc revertTo = from;
 
     public PlayerMoveEvent(EntityPlayer player, Location3dc from, Location3dc to) {
         super(player);

--- a/server/src/main/java/org/allaymc/server/world/service/AllayEntityPhysicsService.java
+++ b/server/src/main/java/org/allaymc/server/world/service/AllayEntityPhysicsService.java
@@ -630,8 +630,10 @@ public class AllayEntityPhysicsService implements EntityPhysicsService {
 
                 var event = new PlayerMoveEvent(player, player.getLocation(), clientMove.newLoc());
                 if (!event.call()) {
-                    // Let client back to the previous pos
-                    player.teleport(event.getFrom());
+                    // Teleport player to specified revert position, if specified.
+                    if (event.getRevertTo() != null) {
+                        player.teleport(event.getRevertTo());
+                    }
                     continue;
                 }
 


### PR DESCRIPTION
I think there is room for improvement in PlayerMoveEvent cancellation handling.

Currently, a cancelled event always causes a teleport to the initial (`from`) position before processing returns early:
https://github.com/AllayMC/Allay/blob/1066011a0527d3aae84d0cad05c5f9e5e26ba913/server/src/main/java/org/allaymc/server/world/service/AllayEntityPhysicsService.java#L631-L636
This can be quite limiting. For example, there is no way to implement custom illegal-movement handling (e.g. reverting the player to a server-side simulated position) without either double-teleporting or allowing the server to accept invalid movement for a few ticks. For example, I cannot safely prevent the player from exceeding world borders by teleporting them to spawn without either double-teleporting or temporarily allowing an invalid state.

My solution is to introduce a new field for PlayerMoveEvent, `Location3dc revertTo = from`, and revert to that instead of hardcoding `from`. For exotic use cases -- such as using CorrectMovementPredictionPacket -- null can be specified to omit any server-side synchronization entirely.