### PR TITLE
fix: PlayerMoveEvent default field initialization order

### DIFF
--- a/api/src/main/java/org/allaymc/api/eventbus/event/player/PlayerMoveEvent.java
+++ b/api/src/main/java/org/allaymc/api/eventbus/event/player/PlayerMoveEvent.java
@@ -20,11 +20,12 @@ public class PlayerMoveEvent extends PlayerEvent implements CancellableEvent {
      * If set to null, no teleport would be issued; it up to user to handle client-server movement desync.
      */
     @Setter
-    protected Location3dc revertTo = from;
+    protected Location3dc revertTo;
 
     public PlayerMoveEvent(EntityPlayer player, Location3dc from, Location3dc to) {
         super(player);
         this.from = from;
         this.to = to;
+        this.revertTo = from;
     }
 }


### PR DESCRIPTION
revertTo in PlayerMoveEvent previously was always null instead of defaulting to `from` (due to java initialization order), which is unintended behavior.