### PR TITLE
fix: add ADVENTURE as possible option to defaultGameType

### DIFF
--- a/api/src/main/java/org/allaymc/api/server/ServerSettings.java
+++ b/api/src/main/java/org/allaymc/api/server/ServerSettings.java
@@ -56,7 +56,7 @@ public class ServerSettings extends OkaeriConfig {
 
         @CustomKey("default-game-type")
         @Comment("Determines the default game type of a world when it is created")
-        @Comment("Possible values: SURVIVAL, CREATIVE, SPECTATOR")
+        @Comment("Possible values: SURVIVAL, CREATIVE, ADVENTURE, SPECTATOR")
         private GameType defaultGameType = GameType.CREATIVE;
 
         @CustomKey("default-difficulty")


### PR DESCRIPTION
defaultGameType configuration entry doc seems to omit ADVENTURE option, but it presented in org.cloudburstmc.protocol.bedrock.data.GameType and seems to be perfectly valid option.