### PR TITLE
fix: PlayerCommandEvent now implements CancellableEvent

### DIFF
--- a/api/src/main/java/org/allaymc/api/eventbus/event/player/PlayerCommandEvent.java
+++ b/api/src/main/java/org/allaymc/api/eventbus/event/player/PlayerCommandEvent.java
@@ -3,13 +3,14 @@ package org.allaymc.api.eventbus.event.player;
 import lombok.Getter;
 import lombok.Setter;
 import org.allaymc.api.entity.interfaces.EntityPlayer;
+import org.allaymc.api.eventbus.event.CancellableEvent;
 
 /**
  * @author daoge_cmd
  */
 @Getter
 @Setter
-public class PlayerCommandEvent extends PlayerEvent {
+public class PlayerCommandEvent extends PlayerEvent implements CancellableEvent {
     protected String command;
 
     public PlayerCommandEvent(EntityPlayer player, String command) {


### PR DESCRIPTION
PlayerCommandEvent does not implement CancellableEvent for some reason, and calling .cancel() on it would result in runtime error (why it type unsafe to begin with?), but CommandRequestPacketProcessor already properly handles cancellation logic:
https://github.com/AllayMC/Allay/blob/5d78195b2c0a8b31f65b4232416227b153fc6c54/server/src/main/java/org/allaymc/server/network/processor/impl/ingame/CommandRequestPacketProcessor.java#L19-L22
Simply adding `implements CancellableEvent` clause allows proper .cancel() behavior.