### PR TITLE
fix: in-game change of default game type will now affect current world settings instead of global configuration state

### DIFF
--- a/server/src/main/java/org/allaymc/server/network/processor/impl/ingame/SetDefaultGameTypePacketProcessor.java
+++ b/server/src/main/java/org/allaymc/server/network/processor/impl/ingame/SetDefaultGameTypePacketProcessor.java
@@ -1,7 +1,6 @@
 package org.allaymc.server.network.processor.impl.ingame;
 
 import org.allaymc.api.entity.interfaces.EntityPlayer;
-import org.allaymc.api.server.Server;
 import org.allaymc.server.network.processor.PacketProcessor;
 import org.cloudburstmc.protocol.bedrock.data.GameType;
 import org.cloudburstmc.protocol.bedrock.packet.BedrockPacketType;
@@ -15,7 +14,7 @@ public class SetDefaultGameTypePacketProcessor extends PacketProcessor<SetDefaul
     @Override
     public void handleSync(EntityPlayer player, SetDefaultGameTypePacket packet, long receiveTime) {
         if (!player.isOperator()) return;
-        Server.SETTINGS.genericSettings().defaultGameType(GameType.from(packet.getGamemode()));
+        player.getWorld().getWorldData().setGameType(GameType.from(packet.getGamemode()));
     }
 
     @Override


### PR DESCRIPTION
Currently, changing the default game type through the in-game menu changes the global configuration state of the defaultGameType option (which, to my understanding, does not even persist after reboots) and does not affect the default game type in any of the existing worlds. The proposed solution is to change the default game type of the world where the request was made, which would be more intuitive and would persist after restarts.
May resolve https://github.com/AllayMC/Allay/issues/702.