### PR TITLE
fix: ignore food exhaust logic on peaceful mode

### DIFF
--- a/server/src/main/java/org/allaymc/server/entity/component/player/EntityPlayerAttributeComponentImpl.java
+++ b/server/src/main/java/org/allaymc/server/entity/component/player/EntityPlayerAttributeComponentImpl.java
@@ -159,7 +159,7 @@ public class EntityPlayerAttributeComponentImpl extends EntityAttributeComponent
 
     @Override
     public void exhaust(float level) {
-        if (thisPlayer.getGameType() == GameType.CREATIVE) {
+        if (thisPlayer.getGameType() == GameType.CREATIVE || thisPlayer.getWorld().getWorldData().getDifficulty() == Difficulty.PEACEFUL) {
             return;
         }
 


### PR DESCRIPTION
Currently peaceful mode only causes some food points to be added once a few ticks instead of completely freezing food processing, which results in food level flickering - hunger level is lowered and after some short time restored back. Expected behavior would be is to additionally completely stop any food processing.