### PR TITLE
fix: log pipeline errors instead of throwing uncatched exception

### DIFF
--- a/server/src/main/java/org/allaymc/server/eventbus/MethodEventHandler.java
+++ b/server/src/main/java/org/allaymc/server/eventbus/MethodEventHandler.java
@@ -2,8 +2,7 @@ package org.allaymc.server.eventbus;
 
 import me.sunlan.fastreflection.FastMemberLoader;
 import me.sunlan.fastreflection.FastMethod;
-import org.allaymc.api.eventbus.EventException;
-
+import lombok.extern.slf4j.Slf4j;
 import java.lang.reflect.Method;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -12,6 +11,7 @@ import java.util.concurrent.ExecutorService;
 /**
  * @author daoge_cmd
  */
+@Slf4j
 public class MethodEventHandler extends AbstractEventHandler {
 
     protected static final Map<ClassLoader, FastMemberLoader> FAST_MEMBER_LOADERS = new ConcurrentHashMap<>();
@@ -37,7 +37,7 @@ public class MethodEventHandler extends AbstractEventHandler {
         try {
             method.invoke(instance, event);
         } catch (Throwable e) {
-            throw new EventException(e);
+            log.error("Unhandled exception occurred during event handling ", e);
         }
     }
 }


### PR DESCRIPTION
currently any exception thrown in event handlers propagates until the last handler in the netty pipeline and can mess up the entire event-handling pipeline, including even server built-in handlers. e.g., if an exception is thrown during a LoginEvent processing, the state does not change to LOGGED_IN, and no packet handlers are registered for this state. proposed solution is to simply log the error at the end of the pipeline.