### PR TITLE
fix: npe during failed login data deserialization

### DIFF
--- a/server/src/main/java/org/allaymc/server/network/processor/login/LoginPacketProcessor.java
+++ b/server/src/main/java/org/allaymc/server/network/processor/login/LoginPacketProcessor.java
@@ -30,7 +30,7 @@ public class LoginPacketProcessor extends ILoginPacketProcessor<LoginPacket> {
         try {
             loginData = AllayLoginData.decode(packet);
         } catch (Throwable t) {
-            log.warn("Failed to decode login data of player {}", player.getOriginName(), t);
+            log.warn("Failed to decode login data of {}", player.getSocketAddress(), t);
             player.disconnect();
             return;
         }


### PR DESCRIPTION
getOriginName() delegates to getLoginData().getXname() while it's null, causing npe.