### PR TITLE
fix(gc): Format the memory release value displayed by the GC command to retain two decimal places

### DIFF
--- a/server/src/main/java/org/allaymc/server/command/defaults/GCCommand.java
+++ b/server/src/main/java/org/allaymc/server/command/defaults/GCCommand.java
@@ -27,7 +27,7 @@ public class GCCommand extends VanillaCommand {
             }
             System.gc();
             var freedMemory = memory - getCurrentMemoryUsage();
-            context.getSender().sendTranslatable(TrKeys.ALLAY_COMMAND_GC_COMPLETED, freedMemory);
+            context.getSender().sendTranslatable(TrKeys.ALLAY_COMMAND_GC_COMPLETED, String.format("%.2f",freedMemory));
             return context.success();
         });
     }


### PR DESCRIPTION
RT