### PR TITLE
feat: add end crystal placement and explosion behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,12 +18,14 @@ Unless otherwise specified, any version comparison below is the comparison of th
 
 - (API) Added API for setting player hud element's visibility.
 - Implemented Totem of Undying activation for players.
+- Implemented End Crystal placement and explosion behavior.
 
 ### Changed
 
 - (API) Refactor and clean up the config util under `org.allaymc.api.config`. This refactor is backward-compatible and shouldn't affect any plugin.
 - (API) Added `ServerPlayerEvent` base class for all `Player` related events under `org.allaymc.api.eventbus.event.server` package.
 - (API) Made `AllayAPI.APIInstanceHolder<T>` public in allay-api by removing the `@ApiStatus.Internal` annotation.
+- (API) `EntityEnderCrystal` now extends `EntityLiving` to support living components.
 
 ### Removed
 

--- a/api/src/main/java/org/allaymc/api/entity/interfaces/EntityEnderCrystal.java
+++ b/api/src/main/java/org/allaymc/api/entity/interfaces/EntityEnderCrystal.java
@@ -1,7 +1,5 @@
 package org.allaymc.api.entity.interfaces;
 
-import org.allaymc.api.entity.Entity;
-
-public interface EntityEnderCrystal extends Entity {
+public interface EntityEnderCrystal extends EntityLiving {
 
 }

--- a/server/src/main/java/org/allaymc/server/entity/component/EntityEnderCrystalBaseComponentImpl.java
+++ b/server/src/main/java/org/allaymc/server/entity/component/EntityEnderCrystalBaseComponentImpl.java
@@ -1,0 +1,69 @@
+package org.allaymc.server.entity.component;
+
+import org.allaymc.api.entity.EntityInitInfo;
+import org.allaymc.api.entity.component.EntityLivingComponent;
+import org.allaymc.api.entity.interfaces.EntityEnderDragon;
+import org.allaymc.api.eventbus.EventHandler;
+import org.allaymc.api.eventbus.event.entity.EntityExplodeEvent;
+import org.allaymc.api.world.Explosion;
+import org.allaymc.api.world.gamerule.GameRule;
+import org.allaymc.server.component.annotation.Dependency;
+import org.allaymc.server.entity.component.event.CEntityAfterDamageEvent;
+import org.joml.primitives.AABBd;
+import org.joml.primitives.AABBdc;
+
+/**
+ * @author ClexaGod
+ */
+public class EntityEnderCrystalBaseComponentImpl extends EntityBaseComponentImpl {
+    @Dependency
+    protected EntityLivingComponent livingComponent;
+
+    protected boolean detonated;
+
+    public EntityEnderCrystalBaseComponentImpl(EntityInitInfo info) {
+        super(info);
+    }
+
+    @Override
+    public AABBdc getAABB() {
+        return new AABBd(-0.5, 0.0, -0.5, 0.5, 2.0, 0.5);
+    }
+
+    @Override
+    public boolean hasEntityCollision() {
+        return false;
+    }
+
+    @EventHandler
+    protected void onDamage(CEntityAfterDamageEvent event) {
+        if (detonated || !isSpawned()) {
+            return;
+        }
+
+        var lastDamage = livingComponent.getLastDamage();
+        if (lastDamage == null) {
+            return;
+        }
+
+        if (lastDamage.getAttacker() instanceof EntityEnderDragon) {
+            return;
+        }
+
+        explode();
+    }
+
+    protected void explode() {
+        var explosion = new Explosion(6);
+        explosion.setEntity(thisEntity);
+        explosion.setDestroyBlocks(thisEntity.getWorld().getWorldData().<Boolean>getGameRuleValue(GameRule.MOB_GRIEFING));
+        var event = new EntityExplodeEvent(thisEntity, explosion);
+        if (!event.call()) {
+            return;
+        }
+
+        detonated = true;
+        remove();
+        explosion.explode(getDimension(), location.x, location.y, location.z);
+    }
+}

--- a/server/src/main/java/org/allaymc/server/entity/impl/EntityEnderCrystalImpl.java
+++ b/server/src/main/java/org/allaymc/server/entity/impl/EntityEnderCrystalImpl.java
@@ -1,16 +1,20 @@
 package org.allaymc.server.entity.impl;
 
+import lombok.experimental.Delegate;
 import org.allaymc.api.component.Component;
 import org.allaymc.api.entity.EntityInitInfo;
+import org.allaymc.api.entity.component.EntityLivingComponent;
 import org.allaymc.api.entity.interfaces.EntityEnderCrystal;
 import org.allaymc.server.component.ComponentProvider;
 
 import java.util.List;
 
 public class EntityEnderCrystalImpl extends EntityImpl implements EntityEnderCrystal {
+    @Delegate
+    protected EntityLivingComponent livingComponent;
+
     public EntityEnderCrystalImpl(EntityInitInfo initInfo,
                                   List<ComponentProvider<? extends Component>> componentProviders) {
         super(initInfo, componentProviders);
-        ;
     }
 }

--- a/server/src/main/java/org/allaymc/server/entity/type/EntityTypeInitializer.java
+++ b/server/src/main/java/org/allaymc/server/entity/type/EntityTypeInitializer.java
@@ -3,6 +3,7 @@ package org.allaymc.server.entity.type;
 import lombok.experimental.UtilityClass;
 import org.allaymc.api.entity.damage.DamageContainer;
 import org.allaymc.api.entity.damage.DamageType;
+import org.allaymc.api.entity.interfaces.EntityEnderDragon;
 import org.allaymc.api.entity.type.EntityTypes;
 import org.allaymc.server.entity.component.*;
 import org.allaymc.server.entity.component.player.EntityPlayerBaseComponentImpl;
@@ -126,6 +127,52 @@ public final class EntityTypeInitializer {
                 .vanillaEntity(EntityId.TNT)
                 .addComponent(EntityTntBaseComponentImpl::new, EntityTntBaseComponentImpl.class)
                 .addComponent(EntityTntPhysicsComponentImpl::new, EntityTntPhysicsComponentImpl.class)
+                .build();
+    }
+
+    public static void initEnderCrystal() {
+        EntityTypes.ENDER_CRYSTAL = AllayEntityType
+                .builder(EntityEnderCrystalImpl.class)
+                .vanillaEntity(EntityId.ENDER_CRYSTAL)
+                .addComponent(EntityEnderCrystalBaseComponentImpl::new, EntityEnderCrystalBaseComponentImpl.class)
+                .addComponent(() -> {
+                    var component = new EntityLivingComponentImpl() {
+                        @Override
+                        public boolean canBeAttacked(DamageContainer damage) {
+                            if (damage.getAttacker() instanceof EntityEnderDragon) {
+                                return false;
+                            }
+                            return super.canBeAttacked(damage);
+                        }
+
+                        @Override
+                        public boolean hasFallDamage() {
+                            return false;
+                        }
+
+                        @Override
+                        public boolean hasFireDamage() {
+                            return false;
+                        }
+
+                        @Override
+                        public boolean hasDrowningDamage() {
+                            return false;
+                        }
+
+                        @Override
+                        public boolean isFireproof() {
+                            return true;
+                        }
+
+                        @Override
+                        protected boolean hasDeadTimer() {
+                            return false;
+                        }
+                    };
+                    component.setMaxHealth(5);
+                    return component;
+                }, EntityLivingComponentImpl.class)
                 .build();
     }
 

--- a/server/src/main/java/org/allaymc/server/item/component/ItemEndCrystalBaseComponentImpl.java
+++ b/server/src/main/java/org/allaymc/server/item/component/ItemEndCrystalBaseComponentImpl.java
@@ -1,0 +1,77 @@
+package org.allaymc.server.item.component;
+
+import org.allaymc.api.block.data.BlockFace;
+import org.allaymc.api.block.dto.PlayerInteractInfo;
+import org.allaymc.api.block.type.BlockTypes;
+import org.allaymc.api.entity.EntityInitInfo;
+import org.allaymc.api.entity.type.EntityTypes;
+import org.allaymc.api.item.ItemStackInitInfo;
+import org.allaymc.api.player.GameMode;
+import org.allaymc.api.world.Dimension;
+import org.joml.Vector3d;
+import org.joml.Vector3ic;
+import org.joml.primitives.AABBd;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * @author ClexaGod
+ */
+public class ItemEndCrystalBaseComponentImpl extends ItemBaseComponentImpl {
+    public ItemEndCrystalBaseComponentImpl(ItemStackInitInfo initInfo) {
+        super(initInfo);
+    }
+
+    @Override
+    public boolean useItemOnBlock(Dimension dimension, Vector3ic placeBlockPos, PlayerInteractInfo interactInfo) {
+        super.useItemOnBlock(dimension, placeBlockPos, interactInfo);
+
+        if (interactInfo == null || interactInfo.player() == null) {
+            return false;
+        }
+
+        var player = interactInfo.player();
+        if (player.getGameMode() == GameMode.ADVENTURE || player.getGameMode() == GameMode.SPECTATOR) {
+            return false;
+        }
+
+        if (interactInfo.blockFace() != BlockFace.UP) {
+            return false;
+        }
+
+        var clickedBlockState = interactInfo.getClickedBlock();
+        var clickedBlockType = clickedBlockState.getBlockType();
+        if (clickedBlockType != BlockTypes.OBSIDIAN && clickedBlockType != BlockTypes.BEDROCK) {
+            return false;
+        }
+
+        if (dimension.getBlockState(placeBlockPos).getBlockType() != BlockTypes.AIR) {
+            return false;
+        }
+        var abovePos = BlockFace.UP.offsetPos(placeBlockPos);
+        if (dimension.getBlockState(abovePos).getBlockType() != BlockTypes.AIR) {
+            return false;
+        }
+
+        var basePos = interactInfo.clickedBlockPos();
+        var aabb = new AABBd(basePos.x(), basePos.y(), basePos.z(), basePos.x() + 1, basePos.y() + 2, basePos.z() + 1);
+        var collidingEntities = dimension.getEntityManager()
+                .getPhysicsService()
+                .computeCollidingEntities(aabb, entity -> true);
+        if (!collidingEntities.isEmpty()) {
+            return false;
+        }
+
+        var spawnPos = new Vector3d(basePos.x() + 0.5, basePos.y() + 1.0, basePos.z() + 0.5);
+        var crystal = EntityTypes.ENDER_CRYSTAL.createEntity(
+                EntityInitInfo.builder()
+                        .dimension(dimension)
+                        .pos(spawnPos)
+                        .rot(ThreadLocalRandom.current().nextDouble() * 360.0d, 0)
+                        .build()
+        );
+        dimension.getEntityManager().addEntity(crystal);
+        player.tryConsumeItemInHand();
+        return true;
+    }
+}

--- a/server/src/main/java/org/allaymc/server/item/type/ItemTypeInitializer.java
+++ b/server/src/main/java/org/allaymc/server/item/type/ItemTypeInitializer.java
@@ -749,6 +749,14 @@ public final class ItemTypeInitializer {
                 .build();
     }
 
+    public static void initEndCrystal() {
+        ItemTypes.END_CRYSTAL = AllayItemType
+                .builder(ItemEndCrystalStackImpl.class)
+                .vanillaItem(ItemId.END_CRYSTAL)
+                .addComponent(ItemEndCrystalBaseComponentImpl::new, ItemEndCrystalBaseComponentImpl.class)
+                .build();
+    }
+
     public static void initSeeds() {
         ItemTypes.WHEAT_SEEDS = AllayItemType
                 .builder(ItemWheatSeedsStackImpl.class)


### PR DESCRIPTION
Item placement now spawns End Crystal only on obsidian/bedrock with valid clearance.
  - End Crystal explodes on damage with strength 6, respecting MOB_GRIEFING.
  - API alignment: EntityEnderCrystal now extends EntityLiving so living components attach
    cleanly.