### PR TITLE
fix: preserve cause during plugin instance construction for better error messages

### DIFF
--- a/server/src/main/java/org/allaymc/server/plugin/jar/JarPluginLoader.java
+++ b/server/src/main/java/org/allaymc/server/plugin/jar/JarPluginLoader.java
@@ -64,7 +64,7 @@ public class JarPluginLoader implements PluginLoader {
         try {
             pluginInstance = (Plugin) mainClass.getConstructor().newInstance();
         } catch (Exception e) {
-            throw new PluginException(I18n.get().tr(TrKeys.ALLAY_PLUGIN_CONSTRUCT_INSTANCE_ERROR, descriptor.getName(), e));
+            throw new PluginException(I18n.get().tr(TrKeys.ALLAY_PLUGIN_CONSTRUCT_INSTANCE_ERROR, descriptor.getName(), e), e);
         }
 
         // Load plugin's lang files


### PR DESCRIPTION
Initial exception thrown during plugin initialization is not preserved in rethrown PluginException, so cause isn't visible in output, since "allay:plugin.construct.instance.error" tr message stringification doesn't include it.

Before:
```
[17:44:03 INFO] [main] [AllayPluginManager] Loading plugin Practice
[17:44:03 ERROR] [main] [AllayPluginManager] Error while loading plugin Practice. Error: Error while constructing plugin instance for plugin Practice. Error: java.lang.reflect.InvocationTargetException
org.allaymc.api.plugin.PluginException: Error while constructing plugin instance for plugin Practice. Error: java.lang.reflect.InvocationTargetException
	at org.allaymc.server.plugin.jar.JarPluginLoader.loadPlugin(JarPluginLoader.java:67)
	at org.allaymc.server.plugin.AllayPluginManager.onLoad(AllayPluginManager.java:229)
	at org.allaymc.server.plugin.AllayPluginManager.loadPlugins(AllayPluginManager.java:86)
	at org.allaymc.server.AllayServer.start(AllayServer.java:179)
	at org.allaymc.server.Allay.main(Allay.java:112)
```

After:
```
[17:58:46 INFO] [main] [AllayPluginManager] Loading plugin Practice
[17:58:46 ERROR] [main] [AllayPluginManager] Error while loading plugin Practice. Error: Error while constructing plugin instance for plugin Practice. Error: java.lang.reflect.InvocationTargetException
org.allaymc.api.plugin.PluginException: Error while constructing plugin instance for plugin Practice. Error: java.lang.reflect.InvocationTargetException
	at org.allaymc.server.plugin.jar.JarPluginLoader.loadPlugin(JarPluginLoader.java:67)
	at org.allaymc.server.plugin.AllayPluginManager.onLoad(AllayPluginManager.java:229)
	at org.allaymc.server.plugin.AllayPluginManager.loadPlugins(AllayPluginManager.java:86)
	at org.allaymc.server.AllayServer.start(AllayServer.java:179)
	at org.allaymc.server.Allay.main(Allay.java:112)
Caused by: java.lang.reflect.InvocationTargetException
	at java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:74)
	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:502)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:486)
	at org.allaymc.server.plugin.jar.JarPluginLoader.loadPlugin(JarPluginLoader.java:65)
	... 4 more
Caused by: java.lang.ExceptionInInitializerError
	at com.minescar.practice.Entry.<init>(Entry.scala:8)
	at java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)
	... 7 more
Caused by: java.lang.NullPointerException: Cannot invoke "scala.collection.mutable.ArrayBuffer.$plus$eq(Object)" because "com.minescar.anticheat.listener.ValidatorListener$.loginLs" is null
	at com.minescar.anticheat.listener.ValidatorListener$.onLogin(ValidatorListener.scala:60)
	at com.minescar.anticheat.validator.Validator.onLogin(Validator.scala:19)
	at com.minescar.anticheat.validator.impl.LoginValidator.<init>(LoginValidator.scala:60)
	at com.minescar.anticheat.listener.ValidatorListener$.<clinit>(ValidatorListener.scala:27)
	... 9 more
```
