### PR TITLE
deps: bump jline version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -62,6 +62,7 @@ log4j-slf4j2-impl = { group = "org.apache.logging.log4j", name = "log4j-slf4j2-i
 log4j-core = { group = "org.apache.logging.log4j", name = "log4j-core", version.ref = "log4j" }
 # CLI dependencie
 mcterminal = { group = "net.minecrell", name = "terminalconsoleappender", version = "1.3.0" }
+jline-reader = { group = "org.jline", name = "jline-reader", version = "3.30.6" }
 # Code generating
 javapoet = { module = "com.palantir.javapoet:javapoet", version = "0.10.0" }
 # Reflections

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
     implementation(libs.commonslang3)
     implementation(libs.commonsio)
     implementation(libs.mcterminal)
+    implementation(libs.jline.reader)
     implementation(libs.disruptor)
     implementation(libs.netty.epoll)
     implementation(libs.netty.kqueue)


### PR DESCRIPTION
Pressing Enter immediately after Ctrl+C results in a jline "Command interrupted" error, and the terminal halts:
```
[18:45:47 INFO] [main] [AllayServer] Network interface started at 0.0.0.0:19132 (3462 ms)
>
Exception in thread "Console Thread" java.io.IOError: java.io.InterruptedIOException: Command interrupted
at org.jline.terminal.impl.AbstractPosixTerminal.setAttributes(AbstractPosixTerminal.java:54)
at org.jline.reader.impl.LineReaderImpl.readLine(LineReaderImpl.java:729)
at org.jline.reader.impl.LineReaderImpl.readLine(LineReaderImpl.java:468)
at net.minecrell.terminalconsole.SimpleTerminalConsole.readCommands(SimpleTerminalConsole.java:158)
at net.minecrell.terminalconsole.SimpleTerminalConsole.start(SimpleTerminalConsole.java:141)
at java.base/java.lang.VirtualThread.run(VirtualThread.java:329)
Caused by: java.io.InterruptedIOException: Command interrupted
at org.jline.utils.ExecHelper.exec(ExecHelper.java:46)
at org.jline.terminal.impl.ExecPty.doGetConfig(ExecPty.java:175)
at org.jline.terminal.impl.ExecPty.getAttr(ExecPty.java:87)
at org.jline.terminal.impl.ExecPty.doSetAttr(ExecPty.java:93)
at org.jline.terminal.impl.AbstractPty.setAttr(AbstractPty.java:29)
at org.jline.terminal.impl.AbstractPosixTerminal.setAttributes(AbstractPosixTerminal.java:52)
... 5 more
Caused by: java.lang.InterruptedException
at java.base/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:1730)
at java.base/java.lang.ProcessImpl.waitFor(ProcessImpl.java:425)
at org.jline.utils.ExecHelper.waitAndCapture(ExecHelper.java:66)
at org.jline.utils.ExecHelper.exec(ExecHelper.java:36)
... 10 more
```

This issue is reported in jline at https://github.com/jline/jline3/issues/590 and was fixed in commit https://github.com/jline/jline3/commit/9a216cab00a5c3f8458c1a4454236c1eb94b0182, version 3.26.3.

jline is pulled in by the no longer maintained https://github.com/Minecrell/TerminalConsoleAppender, version 3.20.0.

The proposed solution is to bump the org.jline.jline-reader version to the latest 3.30.6. This resolves the issue and does not appear to cause any compatibility problems.