### PR TITLE
fix: use correct ender pearl teleport rotation

### DIFF
--- a/server/src/main/java/org/allaymc/server/entity/component/projectile/EntityEnderPearlPhysicsComponentImpl.java
+++ b/server/src/main/java/org/allaymc/server/entity/component/projectile/EntityEnderPearlPhysicsComponentImpl.java
@@ -6,6 +6,7 @@ import org.allaymc.api.entity.component.EntityProjectileComponent;
 import org.allaymc.api.entity.damage.DamageContainer;
 import org.allaymc.api.entity.interfaces.EntityLiving;
 import org.allaymc.api.eventbus.event.entity.EntityTeleportEvent;
+import org.allaymc.api.math.location.Location3d;
 import org.allaymc.api.world.particle.SimpleParticle;
 import org.allaymc.api.world.sound.SimpleSound;
 import org.allaymc.server.component.annotation.Dependency;
@@ -49,7 +50,16 @@ public class EntityEnderPearlPhysicsComponentImpl extends EntityProjectilePhysic
             return;
         }
 
-        var location = thisEntity.getLocation();
+        var pearlLoc = thisEntity.getLocation();
+        var shooterLoc = shooter.getLocation();
+        var location = new Location3d(
+                pearlLoc.x(),
+                pearlLoc.y(),
+                pearlLoc.z(),
+                shooterLoc.pitch(),
+                shooterLoc.yaw(),
+                pearlLoc.dimension()
+        );
         var dimension = thisEntity.getDimension();
         dimension.addSound(location, SimpleSound.TELEPORT);
         if (!shooter.teleport(location, EntityTeleportEvent.Reason.PROJECTILE)) {


### PR DESCRIPTION
EntityEnderPearlPhysicsComponentImpl.teleport uses the ender pearl’s own location when teleporting the shooter, including pitch and yaw:
https://github.com/AllayMC/Allay/blob/f46f9496a0c751ab45f4b2a4f6fc7d85287ca983/server/src/main/java/org/allaymc/server/entity/component/projectile/EntityEnderPearlPhysicsComponentImpl.java#L52-L57

Yet the projectile's rotation is updated every tick according to its motion:
https://github.com/AllayMC/Allay/blob/f46f9496a0c751ab45f4b2a4f6fc7d85287ca983/server/src/main/java/org/allaymc/server/entity/component/projectile/EntityProjectilePhysicsComponentImpl.java#L161-L164

So the player's rotation can end up in a very unintuitive state after ender pearl teleportation, e.g., facing upwards when the pearl is thrown downward at the feet. Using the shooter's pitch and yaw for the teleport location resolves this issue.

This wasn't the case before, and I'm not sure why it happens now though, I couldn't find any obvious cause in recent commits.