### PR TITLE
fix: account for default interface methods as event handlers

### DIFF
--- a/server/src/main/java/org/allaymc/server/utils/ReflectionUtils.java
+++ b/server/src/main/java/org/allaymc/server/utils/ReflectionUtils.java
@@ -38,18 +38,26 @@ public class ReflectionUtils {
 
     public static List<Method> getAllMethods(Class<?> clazz) {
         Map<String, Method> methods = new HashMap<>();
-
-        var current = clazz;
-        while (current != null) {
-            for (var method : current.getDeclaredMethods()) {
-                var signature = buildMethodSignature(method);
-                methods.putIfAbsent(signature, method);
-            }
-
-            current = current.getSuperclass();
-        }
+        collectAllMethods(clazz, methods, new HashSet<>());
 
         return new ArrayList<>(methods.values());
+    }
+
+    private static void collectAllMethods(Class<?> type, Map<String, Method> methods, Set<Class<?>> visited) {
+        if (type == null || !visited.add(type)) {
+            return;
+        }
+
+        for (var method : type.getDeclaredMethods()) {
+            var signature = buildMethodSignature(method);
+            methods.putIfAbsent(signature, method);
+        }
+
+        for (var iface : type.getInterfaces()) {
+            collectAllMethods(iface, methods, visited);
+        }
+
+        collectAllMethods(type.getSuperclass(), methods, visited);
     }
 
     public static String buildMethodSignature(Method method) {


### PR DESCRIPTION
Accounts for  `onEvent` method in this Scala case:
```
trait ListenerTrait:
    @EventHandler 
    private def onEvent(ev: ???) = ???
    
 object Listener extends ListenerTrait 
 
 Server.getInstance.getEventBus.registerListener(Listener)
 ```
 
And for java default interface methods, to which this code would be translated by scala compiler.