### PR TITLE
fix: preserve log4j config in server jar

### DIFF
--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -87,6 +87,11 @@ tasks {
         archiveFileName = getShadedJarName()
         duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 
+        // Log4j config fix
+        filesMatching("META-INF/org/apache/logging/log4j/core/config/plugins/Log4j2Plugins.dat") {
+            duplicatesStrategy = DuplicatesStrategy.INCLUDE
+        }
+
         transform<Log4j2PluginsCacheFileTransformer>()
         mergeServiceFiles()
 


### PR DESCRIPTION
some recent changes caused log4j config to be omitted from jar and no logs were visible.