### PR TITLE
feat: player phantom mode

### DIFF
--- a/api/src/main/java/org/allaymc/api/entity/component/EntityPlayerBaseComponent.java
+++ b/api/src/main/java/org/allaymc/api/entity/component/EntityPlayerBaseComponent.java
@@ -251,6 +251,25 @@ public interface EntityPlayerBaseComponent extends EntityBaseComponent, ChunkLoa
     }
 
     /**
+     * Sets whether this player should be treated as phantom.
+     * <p>
+     * Players in phantom mode are completely removed from all viewers and cannot be interacted
+     * with by the world, while still being able to interact with the world itself.
+     *
+     * @param phantom whether to enable phantom mode
+     */
+    void setPhantom(boolean phantom);
+
+    /**
+     * Checks whether this player is currently phantom.
+     * <p>
+     * Spectator players always return {@code true}.
+     *
+     * @return {@code true} if the player is phantom
+     */
+    boolean isPhantom();
+
+    /**
      * Gets the score tag of the player.
      *
      * @return the score tag of the player

--- a/server/src/main/java/org/allaymc/server/command/defaults/GameTestCommand.java
+++ b/server/src/main/java/org/allaymc/server/command/defaults/GameTestCommand.java
@@ -295,6 +295,15 @@ public class GameTestCommand extends Command {
                     return context.success();
                 }, SenderType.PLAYER)
                 .root()
+                .key("phantom")
+                .bool("value")
+                .exec((context, player) -> {
+                    boolean value = context.getResult(1);
+                    player.setPhantom(value);
+                    player.sendMessage("Phantom set to " + player.isPhantom());
+                    return context.success();
+                }, SenderType.PLAYER)
+                .root()
                 .key("testsimpleform")
                 .exec((context, player) -> {
                     Forms.simple()

--- a/server/src/main/java/org/allaymc/server/entity/ai/sensor/NearestFeedingPlayerSensor.java
+++ b/server/src/main/java/org/allaymc/server/entity/ai/sensor/NearestFeedingPlayerSensor.java
@@ -39,7 +39,7 @@ public class NearestFeedingPlayerSensor implements Sensor {
 
         for (var player : entity.getDimension().getPlayers()) {
             var playerEntity = player.getControlledEntity();
-            if (playerEntity == null || playerEntity.isDead()) continue;
+            if (playerEntity == null || playerEntity.isDead() || playerEntity.isPhantom()) continue;
 
             double distSq = loc.distanceSquared(playerEntity.getLocation());
             if (distSq > rangeSq) continue;

--- a/server/src/main/java/org/allaymc/server/entity/ai/sensor/NearestPlayerSensor.java
+++ b/server/src/main/java/org/allaymc/server/entity/ai/sensor/NearestPlayerSensor.java
@@ -37,7 +37,7 @@ public class NearestPlayerSensor implements Sensor {
 
         for (var player : entity.getDimension().getPlayers()) {
             var playerEntity = player.getControlledEntity();
-            if (playerEntity == null || playerEntity.isDead()) continue;
+            if (playerEntity == null || playerEntity.isDead() || playerEntity.isPhantom()) continue;
 
             double distSq = loc.distanceSquared(playerEntity.getLocation());
             if (distSq < minRangeSq || distSq > rangeSq) continue;

--- a/server/src/main/java/org/allaymc/server/entity/component/player/EntityPlayerBaseComponentImpl.java
+++ b/server/src/main/java/org/allaymc/server/entity/component/player/EntityPlayerBaseComponentImpl.java
@@ -50,9 +50,10 @@ import org.joml.Vector3d;
 import org.joml.Vector3dc;
 import org.joml.primitives.AABBd;
 import org.joml.primitives.AABBdc;
-
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static org.allaymc.server.network.NetworkHelper.fromNetwork;
@@ -93,6 +94,7 @@ public class EntityPlayerBaseComponentImpl extends EntityBaseComponentImpl imple
     protected Player controller;
     @Getter
     protected GameMode gameMode;
+    protected boolean phantom;
     @Getter
     protected Skin skin;
     protected Location3ic spawnPoint;
@@ -205,6 +207,7 @@ public class EntityPlayerBaseComponentImpl extends EntityBaseComponentImpl imple
         }
 
         gameMode = event.getNewGameMode();
+        var oldGameMode = this.gameMode;
         this.gameMode = gameMode;
         this.manager.callEvent(new CPlayerGameModeChangeEvent(this.gameMode));
 
@@ -222,6 +225,47 @@ public class EntityPlayerBaseComponentImpl extends EntityBaseComponentImpl imple
             this.controller.viewPlayerPermission(this.controller);
         }
         forEachViewers(viewer -> viewer.viewPlayerGameMode(thisPlayer));
+
+        if (isActualPlayer() && (oldGameMode == GameMode.SPECTATOR || this.gameMode == GameMode.SPECTATOR)) {
+            refreshPhantom();
+        }
+    }
+
+    @Override
+    public void setPhantom(boolean phantom) {
+        if (this.phantom == phantom) {
+            return;
+        }
+
+        this.phantom = phantom;
+        refreshPhantom();
+    }
+
+    @Override
+    public boolean isPhantom() {
+        return this.gameMode == GameMode.SPECTATOR || this.phantom;
+    }
+
+    protected void refreshPhantom() {
+        if (!isActualPlayer() || !isAlive()) {
+            return;
+        }
+
+        if (isPhantom()) {
+            despawnFrom(new ArrayList<>(getViewers()));
+            return;
+        }
+
+        var chunk = thisPlayer.getCurrentChunk();
+        if (chunk == null) {
+            return;
+        }
+
+        chunk.getChunkLoaders().stream()
+                .filter(loader -> loader != thisPlayer)
+                .map(loader -> loader.toWorldViewer())
+                .filter(Objects::nonNull)
+                .forEach(this::spawnTo);
     }
 
     @Override
@@ -458,7 +502,7 @@ public class EntityPlayerBaseComponentImpl extends EntityBaseComponentImpl imple
 
     @Override
     protected void tickBlockCollision() {
-        if (this.gameMode == GameMode.SPECTATOR) {
+        if (isPhantom()) {
             return;
         }
 
@@ -561,7 +605,7 @@ public class EntityPlayerBaseComponentImpl extends EntityBaseComponentImpl imple
 
     @Override
     public void spawnTo(WorldViewer viewer) {
-        if (this.controller != viewer) {
+        if (this.controller != viewer && !isPhantom()) {
             super.spawnTo(viewer);
             viewer.viewEntityArmors(thisPlayer);
             viewer.viewEntityHand(thisPlayer);
@@ -965,7 +1009,7 @@ public class EntityPlayerBaseComponentImpl extends EntityBaseComponentImpl imple
 
     @Override
     public boolean hasEntityCollision() {
-        return this.gameMode != GameMode.SPECTATOR;
+        return !isPhantom();
     }
 
     @Override

--- a/server/src/main/java/org/allaymc/server/entity/component/player/EntityPlayerBaseComponentImpl.java
+++ b/server/src/main/java/org/allaymc/server/entity/component/player/EntityPlayerBaseComponentImpl.java
@@ -51,6 +51,7 @@ import org.joml.Vector3dc;
 import org.joml.primitives.AABBd;
 import org.joml.primitives.AABBdc;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -228,6 +229,7 @@ public class EntityPlayerBaseComponentImpl extends EntityBaseComponentImpl imple
 
         if (isActualPlayer() && (oldGameMode == GameMode.SPECTATOR || this.gameMode == GameMode.SPECTATOR)) {
             refreshPhantom();
+            refreshObservedPlayers();
         }
     }
 
@@ -251,9 +253,10 @@ public class EntityPlayerBaseComponentImpl extends EntityBaseComponentImpl imple
             return;
         }
 
-        if (isPhantom()) {
-            despawnFrom(new ArrayList<>(getViewers()));
-            return;
+        for (var viewer : new ArrayList<>(getViewers())) {
+            if (!shouldBeVisibleTo(viewer)) {
+                despawnFrom(viewer);
+            }
         }
 
         var chunk = thisPlayer.getCurrentChunk();
@@ -265,7 +268,62 @@ public class EntityPlayerBaseComponentImpl extends EntityBaseComponentImpl imple
                 .filter(loader -> loader != thisPlayer)
                 .map(loader -> loader.toWorldViewer())
                 .filter(Objects::nonNull)
+                .filter(viewer -> !getViewers().contains(viewer))
                 .forEach(this::spawnTo);
+    }
+
+    protected boolean shouldBeVisibleTo(WorldViewer viewer) {
+        if (this.phantom) {
+            return false;
+        }
+
+        if (this.gameMode != GameMode.SPECTATOR) {
+            return true;
+        }
+
+        if (!(viewer instanceof Player player)) {
+            return false;
+        }
+
+        var viewerEntity = player.getControlledEntity();
+        return viewerEntity != null && viewerEntity.getGameMode() == GameMode.SPECTATOR;
+    }
+
+    protected void refreshObservedPlayers() {
+        if (!isActualPlayer()) {
+            return;
+        }
+
+        var location = thisPlayer.getLocation();
+        var centerChunkX = (int) location.x() >> 4;
+        var centerChunkZ = (int) location.z() >> 4;
+        var radius = thisPlayer.getChunkLoadingRadius();
+        var refreshed = new HashSet<Long>();
+
+        for (int rx = -radius; rx <= radius; rx++) {
+            for (int rz = -radius; rz <= radius; rz++) {
+                if (rx * rx + rz * rz > radius * radius) {
+                    continue;
+                }
+
+                thisPlayer.getDimension().getEntityManager().forEachEntitiesInChunkImmediately(centerChunkX + rx, centerChunkZ + rz, entity -> {
+                    if (!(entity instanceof EntityPlayer player) || player == thisPlayer) {
+                        return;
+                    }
+
+                    if (player.getGameMode() != GameMode.SPECTATOR && !player.isPhantom()) {
+                        return;
+                    }
+
+                    if (!refreshed.add(player.getRuntimeId())) {
+                        return;
+                    }
+
+                    player.despawnFrom(this.controller);
+                    player.spawnTo(this.controller);
+                });
+            }
+        }
     }
 
     @Override
@@ -605,7 +663,7 @@ public class EntityPlayerBaseComponentImpl extends EntityBaseComponentImpl imple
 
     @Override
     public void spawnTo(WorldViewer viewer) {
-        if (this.controller != viewer && !isPhantom()) {
+        if (this.controller != viewer && shouldBeVisibleTo(viewer)) {
             super.spawnTo(viewer);
             viewer.viewEntityArmors(thisPlayer);
             viewer.viewEntityHand(thisPlayer);

--- a/server/src/main/java/org/allaymc/server/entity/component/player/EntityPlayerContainerHolderComponentImpl.java
+++ b/server/src/main/java/org/allaymc/server/entity/component/player/EntityPlayerContainerHolderComponentImpl.java
@@ -140,7 +140,7 @@ public class EntityPlayerContainerHolderComponentImpl extends EntityContainerHol
     }
 
     protected void tickPickUpEntities() {
-        if (!thisPlayer.isCurrentChunkLoaded()) {
+        if (!thisPlayer.isCurrentChunkLoaded() || thisPlayer.isPhantom()) {
             return;
         }
 

--- a/server/src/main/java/org/allaymc/server/entity/component/player/EntityPlayerLivingComponentImpl.java
+++ b/server/src/main/java/org/allaymc/server/entity/component/player/EntityPlayerLivingComponentImpl.java
@@ -37,8 +37,12 @@ public class EntityPlayerLivingComponentImpl extends EntityLivingComponentImpl {
 
     @Override
     public boolean canBeAttacked(DamageContainer damage) {
+        if (thisPlayer.isPhantom()) {
+            return damage.getDamageType() == DamageType.API;
+        }
+
         var gameMode = thisPlayer.getGameMode();
-        if (gameMode == GameMode.SPECTATOR || gameMode == GameMode.CREATIVE) {
+        if (gameMode == GameMode.CREATIVE) {
             return damage.getDamageType() == DamageType.API;
         }
 

--- a/server/src/main/java/org/allaymc/server/entity/component/projectile/EntityProjectilePhysicsComponentImpl.java
+++ b/server/src/main/java/org/allaymc/server/entity/component/projectile/EntityProjectilePhysicsComponentImpl.java
@@ -4,6 +4,7 @@ import org.allaymc.api.block.dto.Block;
 import org.allaymc.api.entity.Entity;
 import org.allaymc.api.entity.component.EntityAgeComponent;
 import org.allaymc.api.entity.component.EntityProjectileComponent;
+import org.allaymc.api.entity.interfaces.EntityPlayer;
 import org.allaymc.api.entity.interfaces.EntityProjectile;
 import org.allaymc.api.eventbus.event.entity.ProjectileHitEvent;
 import org.allaymc.api.math.MathUtils;
@@ -144,6 +145,10 @@ public class EntityProjectilePhysicsComponentImpl extends EntityPhysicsComponent
         // Ray cast entities
         dimension.getEntityManager().getPhysicsService().computeCollidingEntities(aabb).forEach(entity -> {
             if (entity == thisEntity || (ageComponent.getAge() <= 10 && entity == projectileComponent.getShooter())) {
+                return;
+            }
+
+            if (entity instanceof EntityPlayer player && player.isPhantom()) {
                 return;
             }
 

--- a/server/src/main/java/org/allaymc/server/player/AllayPlayer.java
+++ b/server/src/main/java/org/allaymc/server/player/AllayPlayer.java
@@ -388,10 +388,6 @@ public class AllayPlayer implements Player {
 
     @Override
     public void viewEntity(Entity entity) {
-        if (entity instanceof EntityPlayer player && player != this.controlledEntity && player.isPhantom()) {
-            return;
-        }
-
         var l = entity.getLocation();
         var position = Vector3f.from(l.x(), l.y() + NETWORK_OFFSETS.get().getOrDefault(entity.getEntityType(), 0.0f), l.z());
         var motion = switch (entity) {

--- a/server/src/main/java/org/allaymc/server/player/AllayPlayer.java
+++ b/server/src/main/java/org/allaymc/server/player/AllayPlayer.java
@@ -388,6 +388,10 @@ public class AllayPlayer implements Player {
 
     @Override
     public void viewEntity(Entity entity) {
+        if (entity instanceof EntityPlayer player && player != this.controlledEntity && player.isPhantom()) {
+            return;
+        }
+
         var l = entity.getLocation();
         var position = Vector3f.from(l.x(), l.y() + NETWORK_OFFSETS.get().getOrDefault(entity.getEntityType(), 0.0f), l.z());
         var motion = switch (entity) {


### PR DESCRIPTION
Player entities now can be marked as phantom, resulting in them being completely removed from all other viewers and preventing from world interacting with them. Always enabled for spectator mode. Use cases: spectator, /vanish command, non-spectator viewer state (coupled with build mine and attack abilities disabled) like after death on the hive.