### PR TITLE
fix: ignore case for online player command lookups

### DIFF
--- a/server/src/main/java/org/allaymc/server/command/defaults/DeOpCommand.java
+++ b/server/src/main/java/org/allaymc/server/command/defaults/DeOpCommand.java
@@ -21,6 +21,10 @@ public class DeOpCommand extends Command {
             String player = context.getResult(0);
 
             var manager = Server.getInstance().getPlayerManager();
+            var onlinePlayer = manager.getPlayerByName(player);
+            if (onlinePlayer != null) {
+                player = onlinePlayer.getOriginName();
+            }
             if (!manager.isOperator(player)) {
                 context.addError("%" + TrKeys.MC_COMMANDS_DEOP_FAILED, player);
                 return context.fail();
@@ -28,9 +32,9 @@ public class DeOpCommand extends Command {
 
             manager.setOperator(player, false);
             context.addOutput(TrKeys.MC_COMMANDS_DEOP_SUCCESS, player);
-            manager.getPlayers().values().stream()
-                    .filter(p -> p.getLoginData().getUuid().toString().equals(player) || p.getOriginName().equals(player))
-                    .forEach(p -> p.sendTranslatable(TrKeys.MC_COMMANDS_DEOP_MESSAGE));
+            if (onlinePlayer != null) {
+                onlinePlayer.sendTranslatable(TrKeys.MC_COMMANDS_DEOP_MESSAGE);
+            }
             return context.success();
         });
     }

--- a/server/src/main/java/org/allaymc/server/command/defaults/OpCommand.java
+++ b/server/src/main/java/org/allaymc/server/command/defaults/OpCommand.java
@@ -21,6 +21,10 @@ public class OpCommand extends Command {
             String player = context.getResult(0);
 
             var manager = Server.getInstance().getPlayerManager();
+            var onlinePlayer = manager.getPlayerByName(player);
+            if (onlinePlayer != null) {
+                player = onlinePlayer.getOriginName();
+            }
             if (manager.isOperator(player)) {
                 context.addError("%" + TrKeys.MC_COMMANDS_OP_FAILED, player);
                 return context.fail();
@@ -28,9 +32,9 @@ public class OpCommand extends Command {
 
             manager.setOperator(player, true);
             context.addOutput(TrKeys.MC_COMMANDS_OP_SUCCESS, player);
-            manager.getPlayers().values().stream()
-                    .filter(p -> p.getLoginData().getUuid().toString().equals(player) || p.getOriginName().equals(player))
-                    .forEach(p -> p.sendTranslatable(TrKeys.MC_COMMANDS_OP_MESSAGE));
+            if (onlinePlayer != null) {
+                onlinePlayer.sendTranslatable(TrKeys.MC_COMMANDS_OP_MESSAGE);
+            }
             return context.success();
         });
     }

--- a/server/src/main/java/org/allaymc/server/command/defaults/WhitelistCommand.java
+++ b/server/src/main/java/org/allaymc/server/command/defaults/WhitelistCommand.java
@@ -51,10 +51,10 @@ public class WhitelistCommand extends Command {
                 .root()
                 .key("list")
                 .exec(context -> {
-                    var whitelist = Server.getInstance().getPlayerManager().getWhitelistedPlayers();
-                    var onlineCount = (int) Server.getInstance().getPlayerManager().getPlayers().values().stream()
-                            .filter(player -> whitelist.contains(player.getLoginData().getUuid().toString()) ||
-                                              whitelist.contains(player.getOriginName()))
+                    var playerManager = Server.getInstance().getPlayerManager();
+                    var whitelist = playerManager.getWhitelistedPlayers();
+                    var onlineCount = (int) playerManager.getPlayers().values().stream()
+                            .filter(playerManager::isWhitelisted)
                             .count();
                     context.addOutput(TrKeys.MC_COMMANDS_ALLOWLIST_LIST, whitelist.size(), onlineCount);
                     context.addOutput(String.join(", ", whitelist));

--- a/server/src/main/java/org/allaymc/server/command/selector/args/Name.java
+++ b/server/src/main/java/org/allaymc/server/command/selector/args/Name.java
@@ -28,8 +28,8 @@ public class Name extends CachedSimpleSelectorArgument {
         }
 
         return entity ->
-                include.stream().allMatch(name -> entity.getCommandSenderName().equals(name)) &&
-                exclude.stream().noneMatch(name -> entity.getCommandSenderName().equals(name));
+                include.stream().allMatch(name -> entity.getCommandSenderName().equalsIgnoreCase(name)) &&
+                exclude.stream().noneMatch(name -> entity.getCommandSenderName().equalsIgnoreCase(name));
     }
 
     @Override

--- a/server/src/main/java/org/allaymc/server/player/AllayPlayerManager.java
+++ b/server/src/main/java/org/allaymc/server/player/AllayPlayerManager.java
@@ -78,6 +78,11 @@ public class AllayPlayerManager implements PlayerManager {
     }
 
     @Override
+    public Player getPlayerByName(String playerName) {
+        return PlayerNameMatcher.findOnlinePlayerByName(players, playerName);
+    }
+
+    @Override
     public int getMaxPlayerCount() {
         return maxPlayerCount;
     }
@@ -97,11 +102,12 @@ public class AllayPlayerManager implements PlayerManager {
 
     @Override
     public boolean isBanned(String uuidOrName) {
-        return banInfo.bannedPlayers().contains(uuidOrName);
+        return PlayerNameMatcher.containsStoredIdentity(banInfo.bannedPlayers(), normalizeOnlinePlayerIdentity(uuidOrName));
     }
 
     @Override
     public boolean ban(String uuidOrName) {
+        uuidOrName = normalizeOnlinePlayerIdentity(uuidOrName);
         if (isBanned(uuidOrName)) {
             return false;
         }
@@ -112,8 +118,9 @@ public class AllayPlayerManager implements PlayerManager {
         }
 
         banInfo.bannedPlayers().add(uuidOrName);
+        var bannedIdentity = uuidOrName;
         players.values().stream()
-                .filter(player -> player.getLoginData().getUuid().toString().equals(uuidOrName) || player.getOriginName().equals(uuidOrName))
+                .filter(player -> PlayerNameMatcher.matchesPlayer(player, bannedIdentity))
                 .forEach(player -> player.disconnect("You are banned!"));
 
         return true;
@@ -121,6 +128,7 @@ public class AllayPlayerManager implements PlayerManager {
 
     @Override
     public boolean unban(String uuidOrName) {
+        uuidOrName = resolveStoredIdentity(banInfo.bannedPlayers(), uuidOrName);
         if (!isBanned(uuidOrName)) {
             return false;
         }
@@ -205,11 +213,12 @@ public class AllayPlayerManager implements PlayerManager {
 
     @Override
     public boolean isWhitelisted(String uuidOrName) {
-        return whitelist.whitelist().contains(uuidOrName);
+        return PlayerNameMatcher.containsStoredIdentity(whitelist.whitelist(), normalizeOnlinePlayerIdentity(uuidOrName));
     }
 
     @Override
     public boolean addToWhitelist(String uuidOrName) {
+        uuidOrName = normalizeOnlinePlayerIdentity(uuidOrName);
         if (isWhitelisted(uuidOrName)) {
             return false;
         }
@@ -224,6 +233,7 @@ public class AllayPlayerManager implements PlayerManager {
 
     @Override
     public boolean removeFromWhitelist(String uuidOrName) {
+        uuidOrName = resolveStoredIdentity(whitelist.whitelist(), uuidOrName);
         if (!isWhitelisted(uuidOrName)) {
             return false;
         }
@@ -234,8 +244,9 @@ public class AllayPlayerManager implements PlayerManager {
         }
 
         whitelist.whitelist().remove(uuidOrName);
+        var whitelistedIdentity = uuidOrName;
         players.values().stream()
-                .filter(player -> player.getLoginData().getUuid().toString().equals(uuidOrName) || player.getOriginName().equals(uuidOrName))
+                .filter(player -> PlayerNameMatcher.matchesPlayer(player, whitelistedIdentity))
                 .forEach(player -> player.disconnect(TrKeys.MC_DISCONNECTIONSCREEN_NOTALLOWED));
         return true;
     }
@@ -247,11 +258,12 @@ public class AllayPlayerManager implements PlayerManager {
 
     @Override
     public boolean isOperator(String uuidOrName) {
-        return operators.operators().contains(uuidOrName);
+        return PlayerNameMatcher.containsStoredIdentity(operators.operators(), normalizeOnlinePlayerIdentity(uuidOrName));
     }
 
     @Override
     public void setOperator(String uuidOrName, boolean value) {
+        uuidOrName = value ? normalizeOnlinePlayerIdentity(uuidOrName) : resolveStoredIdentity(operators.operators(), uuidOrName);
         if (value == isOperator(uuidOrName)) {
             return;
         }
@@ -262,10 +274,20 @@ public class AllayPlayerManager implements PlayerManager {
             operators.operators().remove(uuidOrName);
         }
 
+        var operatorIdentity = uuidOrName;
         players.values().stream()
-                .filter(p -> p.getLoginData().getUuid().toString().equals(uuidOrName) || p.getOriginName().equals(uuidOrName))
+                .filter(player -> PlayerNameMatcher.matchesPlayer(player, operatorIdentity))
                 .findFirst()
                 .ifPresent(player -> player.viewPlayerPermission(player));
+    }
+
+    protected String normalizeOnlinePlayerIdentity(String uuidOrName) {
+        var player = getPlayerByName(uuidOrName);
+        return player != null ? player.getOriginName() : uuidOrName;
+    }
+
+    protected String resolveStoredIdentity(Set<String> identities, String uuidOrName) {
+        return PlayerNameMatcher.resolveStoredIdentity(identities, normalizeOnlinePlayerIdentity(uuidOrName));
     }
 
     public void startNetworkInterfaces() {

--- a/server/src/main/java/org/allaymc/server/player/PlayerNameMatcher.java
+++ b/server/src/main/java/org/allaymc/server/player/PlayerNameMatcher.java
@@ -1,0 +1,74 @@
+package org.allaymc.server.player;
+
+import org.allaymc.api.player.Player;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+final class PlayerNameMatcher {
+    private PlayerNameMatcher() {
+    }
+
+    static Player findOnlinePlayerByName(Map<UUID, Player> players, String playerName) {
+        Player ignoreCaseMatch = null;
+        for (var player : players.values()) {
+            var originName = player.getOriginName();
+            if (originName.equals(playerName)) {
+                return player;
+            }
+            if (originName.equalsIgnoreCase(playerName)) {
+                if (ignoreCaseMatch != null) {
+                    return null;
+                }
+                ignoreCaseMatch = player;
+            }
+        }
+        return ignoreCaseMatch;
+    }
+
+    static boolean matchesPlayer(Player player, String uuidOrName) {
+        return player.getLoginData().getUuid().toString().equals(uuidOrName) ||
+               player.getOriginName().equalsIgnoreCase(uuidOrName);
+    }
+
+    static boolean containsStoredIdentity(Set<String> identities, String uuidOrName) {
+        if (identities.contains(uuidOrName)) {
+            return true;
+        }
+        if (isUuid(uuidOrName)) {
+            return false;
+        }
+        return identities.stream()
+                .filter(identity -> !isUuid(identity))
+                .anyMatch(identity -> identity.equalsIgnoreCase(uuidOrName));
+    }
+
+    static String resolveStoredIdentity(Set<String> identities, String uuidOrName) {
+        if (identities.contains(uuidOrName) || isUuid(uuidOrName)) {
+            return uuidOrName;
+        }
+
+        String ignoreCaseMatch = null;
+        for (var identity : identities) {
+            if (isUuid(identity) || !identity.equalsIgnoreCase(uuidOrName)) {
+                continue;
+            }
+            if (ignoreCaseMatch != null) {
+                return uuidOrName;
+            }
+            ignoreCaseMatch = identity;
+        }
+
+        return ignoreCaseMatch != null ? ignoreCaseMatch : uuidOrName;
+    }
+
+    private static boolean isUuid(String value) {
+        try {
+            UUID.fromString(value);
+            return true;
+        } catch (IllegalArgumentException ignored) {
+            return false;
+        }
+    }
+}

--- a/server/src/test/java/org/allaymc/server/command/selector/args/NameSelectorArgumentTest.java
+++ b/server/src/test/java/org/allaymc/server/command/selector/args/NameSelectorArgumentTest.java
@@ -1,0 +1,32 @@
+package org.allaymc.server.command.selector.args;
+
+import org.allaymc.api.command.selector.SelectorType;
+import org.allaymc.api.entity.Entity;
+import org.allaymc.api.math.location.Location3d;
+import org.allaymc.server.command.MockCommandSender;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class NameSelectorArgumentTest {
+    @Test
+    void matchesNamesIgnoringCase() throws Exception {
+        var entity = Mockito.mock(Entity.class);
+        Mockito.when(entity.getCommandSenderName()).thenReturn("QHYPERQ");
+
+        var predicate = new Name().getPredicate(SelectorType.ALL_PLAYERS, new MockCommandSender(), new Location3d(0, 0, 0, null), "qhyperq");
+
+        assertTrue(predicate.test(entity));
+    }
+
+    @Test
+    void excludesNamesIgnoringCase() throws Exception {
+        var entity = Mockito.mock(Entity.class);
+        Mockito.when(entity.getCommandSenderName()).thenReturn("QHYPERQ");
+
+        var predicate = new Name().getPredicate(SelectorType.ALL_PLAYERS, new MockCommandSender(), new Location3d(0, 0, 0, null), "!qhyperq");
+
+        assertFalse(predicate.test(entity));
+    }
+}

--- a/server/src/test/java/org/allaymc/server/player/PlayerNameMatcherTest.java
+++ b/server/src/test/java/org/allaymc/server/player/PlayerNameMatcherTest.java
@@ -1,0 +1,76 @@
+package org.allaymc.server.player;
+
+import org.allaymc.api.player.LoginData;
+import org.allaymc.api.player.Player;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.LinkedHashMap;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PlayerNameMatcherTest {
+    @Test
+    void findOnlinePlayerByNamePrefersExactMatch() {
+        var lower = mockPlayer("qhyperq");
+        var upper = mockPlayer("QHYPERQ");
+        var players = new LinkedHashMap<UUID, Player>();
+        players.put(lower.getLoginData().getUuid(), lower);
+        players.put(upper.getLoginData().getUuid(), upper);
+
+        assertSame(upper, PlayerNameMatcher.findOnlinePlayerByName(players, "QHYPERQ"));
+    }
+
+    @Test
+    void findOnlinePlayerByNameUsesUniqueIgnoreCaseMatch() {
+        var player = mockPlayer("QHYPERQ");
+        var players = new LinkedHashMap<UUID, Player>();
+        players.put(player.getLoginData().getUuid(), player);
+
+        assertSame(player, PlayerNameMatcher.findOnlinePlayerByName(players, "qhyperq"));
+    }
+
+    @Test
+    void findOnlinePlayerByNameRejectsAmbiguousIgnoreCaseMatch() {
+        var first = mockPlayer("QHYPERQ");
+        var second = mockPlayer("qhyperq");
+        var players = new LinkedHashMap<UUID, Player>();
+        players.put(first.getLoginData().getUuid(), first);
+        players.put(second.getLoginData().getUuid(), second);
+
+        assertNull(PlayerNameMatcher.findOnlinePlayerByName(players, "QhYpErQ"));
+    }
+
+    @Test
+    void containsStoredIdentityMatchesNameIgnoringCase() {
+        assertTrue(PlayerNameMatcher.containsStoredIdentity(Set.of("QHYPERQ"), "qhyperq"));
+    }
+
+    @Test
+    void resolveStoredIdentityReturnsStoredNameCase() {
+        assertEquals("QHYPERQ", PlayerNameMatcher.resolveStoredIdentity(Set.of("QHYPERQ"), "qhyperq"));
+    }
+
+    @Test
+    void matchesPlayerMatchesUuidAndNameIgnoringCase() {
+        var player = mockPlayer("QHYPERQ");
+
+        assertTrue(PlayerNameMatcher.matchesPlayer(player, "qhyperq"));
+        assertTrue(PlayerNameMatcher.matchesPlayer(player, player.getLoginData().getUuid().toString()));
+        assertFalse(PlayerNameMatcher.matchesPlayer(player, "other"));
+    }
+
+    private static Player mockPlayer(String originName) {
+        var player = Mockito.mock(Player.class);
+        var loginData = Mockito.mock(LoginData.class);
+        var uuid = UUID.randomUUID();
+
+        Mockito.when(player.getOriginName()).thenReturn(originName);
+        Mockito.when(player.getLoginData()).thenReturn(loginData);
+        Mockito.when(loginData.getUuid()).thenReturn(uuid);
+
+        return player;
+    }
+}


### PR DESCRIPTION
## Summary
- ignore case when resolving online player names for command lookups
- keep exact match priority and only fall back to a unique case-insensitive online match
- do not guess or rewrite offline names when no online player matches
- apply the same behavior to name selectors and operator/whitelist/ban player-name checks

## Testing
- ./gradlew clean :server:test --tests "org.allaymc.server.player.PlayerNameMatcherTest" --tests "org.allaymc.server.command.selector.args.NameSelectorArgumentTest"
