### PR TITLE
Implement bone meal on grass blocks

### DIFF
--- a/server/src/main/java/org/allaymc/server/block/component/BlockGrassBlockBaseComponentImpl.java
+++ b/server/src/main/java/org/allaymc/server/block/component/BlockGrassBlockBaseComponentImpl.java
@@ -148,11 +148,9 @@ public class BlockGrassBlockBaseComponentImpl extends BlockBaseComponentImpl {
     private int findGrassSurfaceY(Dimension dimension, int x, int originY, int z) {
         for (int offsetY = BONEMEAL_VERTICAL_RANGE; offsetY >= -BONEMEAL_VERTICAL_RANGE; offsetY--) {
             int y = originY + offsetY;
-            if (dimension.getBlockState(x, y, z).getBlockType() != BlockTypes.GRASS_BLOCK) {
-                continue;
-            }
-
-            if (dimension.getBlockState(x, y + 1, z).getBlockType() == BlockTypes.AIR) {
+            var surfaceType = dimension.getBlockState(x, y, z).getBlockType();
+            var aboveType = dimension.getBlockState(x, y + 1, z).getBlockType();
+            if (surfaceType == BlockTypes.GRASS_BLOCK && aboveType == BlockTypes.AIR) {
                 return y;
             }
         }
@@ -169,24 +167,22 @@ public class BlockGrassBlockBaseComponentImpl extends BlockBaseComponentImpl {
         int cumulativeWeight = 0;
         for (var entry : BONEMEAL_VEGETATION) {
             cumulativeWeight += entry.weight();
-            if (roll >= cumulativeWeight) {
-                continue;
-            }
+            if (roll < cumulativeWeight) {
+                var blockType = entry.blockType().get();
+                if (entry.tallPlant()) {
+                    if (dimension.getBlockState(x, y + 1, z).getBlockType() != BlockTypes.AIR) {
+                        return false;
+                    }
 
-            var blockType = entry.blockType().get();
-            if (entry.tallPlant()) {
-                if (dimension.getBlockState(x, y + 1, z).getBlockType() != BlockTypes.AIR) {
-                    return false;
+                    var state = blockType.getDefaultState();
+                    dimension.setBlockState(x, y, z, state.setPropertyValue(BlockPropertyTypes.UPPER_BLOCK_BIT, false));
+                    dimension.setBlockState(x, y + 1, z, state.setPropertyValue(BlockPropertyTypes.UPPER_BLOCK_BIT, true));
+                } else {
+                    dimension.setBlockState(x, y, z, blockType.getDefaultState());
                 }
 
-                var state = blockType.getDefaultState();
-                dimension.setBlockState(x, y, z, state.setPropertyValue(BlockPropertyTypes.UPPER_BLOCK_BIT, false));
-                dimension.setBlockState(x, y + 1, z, state.setPropertyValue(BlockPropertyTypes.UPPER_BLOCK_BIT, true));
-            } else {
-                dimension.setBlockState(x, y, z, blockType.getDefaultState());
+                return true;
             }
-
-            return true;
         }
 
         return false;

--- a/server/src/main/java/org/allaymc/server/block/component/BlockGrassBlockBaseComponentImpl.java
+++ b/server/src/main/java/org/allaymc/server/block/component/BlockGrassBlockBaseComponentImpl.java
@@ -2,7 +2,9 @@ package org.allaymc.server.block.component;
 
 import org.allaymc.api.block.BlockBehavior;
 import org.allaymc.api.block.data.BlockFace;
+import org.allaymc.api.block.dto.PlayerInteractInfo;
 import org.allaymc.api.block.dto.Block;
+import org.allaymc.api.block.property.type.BlockPropertyTypes;
 import org.allaymc.api.block.type.BlockType;
 import org.allaymc.api.block.type.BlockTypes;
 import org.allaymc.api.entity.Entity;
@@ -10,10 +12,15 @@ import org.allaymc.api.eventbus.event.block.BlockFadeEvent;
 import org.allaymc.api.eventbus.event.block.BlockSpreadEvent;
 import org.allaymc.api.item.ItemStack;
 import org.allaymc.api.item.type.ItemTypes;
+import org.allaymc.api.math.MathUtils;
 import org.allaymc.api.math.position.Position3i;
+import org.allaymc.api.world.Dimension;
+import org.allaymc.api.world.particle.SimpleParticle;
 
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Supplier;
 
 /**
  * @author daoge_cmd
@@ -21,9 +28,47 @@ import java.util.concurrent.ThreadLocalRandom;
 public class BlockGrassBlockBaseComponentImpl extends BlockBaseComponentImpl {
 
     public static final int MINIMUM_LIGHT_LEVEL_FOR_SPREADING = 9;
+    private static final int BONEMEAL_ATTEMPTS = 128;
+    private static final int BONEMEAL_HORIZONTAL_RANGE = 4;
+    private static final int BONEMEAL_VERTICAL_RANGE = 2;
+    private static final List<VegetationEntry> BONEMEAL_VEGETATION = List.of(
+            new VegetationEntry(48, () -> BlockTypes.SHORT_GRASS, false),
+            new VegetationEntry(24, () -> BlockTypes.FERN, false),
+            new VegetationEntry(12, () -> BlockTypes.TALL_GRASS, true),
+            new VegetationEntry(8, () -> BlockTypes.LARGE_FERN, true),
+            new VegetationEntry(4, () -> BlockTypes.DANDELION, false),
+            new VegetationEntry(4, () -> BlockTypes.POPPY, false)
+    );
+    private static final int BONEMEAL_VEGETATION_TOTAL_WEIGHT = BONEMEAL_VEGETATION.stream()
+            .mapToInt(VegetationEntry::weight)
+            .sum();
 
     public BlockGrassBlockBaseComponentImpl(BlockType<? extends BlockBehavior> blockType) {
         super(blockType);
+    }
+
+    @Override
+    public boolean onInteract(ItemStack itemStack, Dimension dimension, PlayerInteractInfo interactInfo) {
+        if (super.onInteract(itemStack, dimension, interactInfo)) {
+            return true;
+        }
+
+        if (itemStack == null || itemStack.getItemType() != ItemTypes.BONE_MEAL) {
+            return false;
+        }
+
+        var pos = interactInfo.clickedBlockPos();
+        if (dimension.getBlockState(pos.x(), pos.y() + 1, pos.z()).getBlockType() != BlockTypes.AIR) {
+            return false;
+        }
+
+        if (!growVegetation(dimension, pos.x(), pos.y(), pos.z())) {
+            return false;
+        }
+
+        interactInfo.player().tryConsumeItemInHand();
+        dimension.addParticle(MathUtils.center(pos), SimpleParticle.BONE_MEAL);
+        return true;
     }
 
     @Override
@@ -82,4 +127,70 @@ public class BlockGrassBlockBaseComponentImpl extends BlockBaseComponentImpl {
     public boolean canRandomUpdate() {
         return true;
     }
+
+    private boolean growVegetation(Dimension dimension, int originX, int originY, int originZ) {
+        var random = ThreadLocalRandom.current();
+        var grown = false;
+        for (int i = 0; i < BONEMEAL_ATTEMPTS; i++) {
+            int x = originX + random.nextInt(-BONEMEAL_HORIZONTAL_RANGE, BONEMEAL_HORIZONTAL_RANGE + 1);
+            int z = originZ + random.nextInt(-BONEMEAL_HORIZONTAL_RANGE, BONEMEAL_HORIZONTAL_RANGE + 1);
+            int y = findGrassSurfaceY(dimension, x, originY, z);
+            if (y == Integer.MIN_VALUE) {
+                continue;
+            }
+
+            grown |= placeVegetation(dimension, x, y + 1, z, random);
+        }
+
+        return grown;
+    }
+
+    private int findGrassSurfaceY(Dimension dimension, int x, int originY, int z) {
+        for (int offsetY = BONEMEAL_VERTICAL_RANGE; offsetY >= -BONEMEAL_VERTICAL_RANGE; offsetY--) {
+            int y = originY + offsetY;
+            if (dimension.getBlockState(x, y, z).getBlockType() != BlockTypes.GRASS_BLOCK) {
+                continue;
+            }
+
+            if (dimension.getBlockState(x, y + 1, z).getBlockType() == BlockTypes.AIR) {
+                return y;
+            }
+        }
+
+        return Integer.MIN_VALUE;
+    }
+
+    private boolean placeVegetation(Dimension dimension, int x, int y, int z, ThreadLocalRandom random) {
+        if (dimension.getBlockState(x, y, z).getBlockType() != BlockTypes.AIR) {
+            return false;
+        }
+
+        int roll = random.nextInt(BONEMEAL_VEGETATION_TOTAL_WEIGHT);
+        int cumulativeWeight = 0;
+        for (var entry : BONEMEAL_VEGETATION) {
+            cumulativeWeight += entry.weight();
+            if (roll >= cumulativeWeight) {
+                continue;
+            }
+
+            var blockType = entry.blockType().get();
+            if (entry.tallPlant()) {
+                if (dimension.getBlockState(x, y + 1, z).getBlockType() != BlockTypes.AIR) {
+                    return false;
+                }
+
+                var state = blockType.getDefaultState();
+                dimension.setBlockState(x, y, z, state.setPropertyValue(BlockPropertyTypes.UPPER_BLOCK_BIT, false));
+                dimension.setBlockState(x, y + 1, z, state.setPropertyValue(BlockPropertyTypes.UPPER_BLOCK_BIT, true));
+            } else {
+                dimension.setBlockState(x, y, z, blockType.getDefaultState());
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    private record VegetationEntry(int weight, Supplier<BlockType<?>> blockType, boolean tallPlant) {}
 }

--- a/server/src/main/java/org/allaymc/server/block/component/BlockGrassBlockBaseComponentImpl.java
+++ b/server/src/main/java/org/allaymc/server/block/component/BlockGrassBlockBaseComponentImpl.java
@@ -58,6 +58,10 @@ public class BlockGrassBlockBaseComponentImpl extends BlockBaseComponentImpl {
         }
 
         var pos = interactInfo.clickedBlockPos();
+        if (!dimension.isYInRange(pos.y() + 1)) {
+            return false;
+        }
+
         if (dimension.getBlockState(pos.x(), pos.y() + 1, pos.z()).getBlockType() != BlockTypes.AIR) {
             return false;
         }
@@ -148,6 +152,10 @@ public class BlockGrassBlockBaseComponentImpl extends BlockBaseComponentImpl {
     private int findGrassSurfaceY(Dimension dimension, int x, int originY, int z) {
         for (int offsetY = BONEMEAL_VERTICAL_RANGE; offsetY >= -BONEMEAL_VERTICAL_RANGE; offsetY--) {
             int y = originY + offsetY;
+            if (!dimension.isYInRange(y) || !dimension.isYInRange(y + 1)) {
+                continue;
+            }
+
             var surfaceType = dimension.getBlockState(x, y, z).getBlockType();
             var aboveType = dimension.getBlockState(x, y + 1, z).getBlockType();
             if (surfaceType == BlockTypes.GRASS_BLOCK && aboveType == BlockTypes.AIR) {
@@ -159,6 +167,10 @@ public class BlockGrassBlockBaseComponentImpl extends BlockBaseComponentImpl {
     }
 
     private boolean placeVegetation(Dimension dimension, int x, int y, int z, ThreadLocalRandom random) {
+        if (!dimension.isYInRange(y)) {
+            return false;
+        }
+
         if (dimension.getBlockState(x, y, z).getBlockType() != BlockTypes.AIR) {
             return false;
         }
@@ -170,6 +182,10 @@ public class BlockGrassBlockBaseComponentImpl extends BlockBaseComponentImpl {
             if (roll < cumulativeWeight) {
                 var blockType = entry.blockType().get();
                 if (entry.tallPlant()) {
+                    if (!dimension.isYInRange(y + 1)) {
+                        return false;
+                    }
+
                     if (dimension.getBlockState(x, y + 1, z).getBlockType() != BlockTypes.AIR) {
                         return false;
                     }


### PR DESCRIPTION
## Summary
- add bone meal interaction for grass blocks
- grow short grass, ferns, tall grass, large ferns, and simple flowers around the target block
- consume bone meal only when vegetation was actually generated

## Verification
- ./gradlew :server:compileJava
- ./gradlew :server:shadowJar

Related to https://github.com/AllayMC/Allay/issues/867