### PR TITLE
Fix soul fire and fireproof dropped items

### DIFF
--- a/api/src/main/java/org/allaymc/api/item/data/ItemTags.java
+++ b/api/src/main/java/org/allaymc/api/item/data/ItemTags.java
@@ -139,6 +139,8 @@ public interface ItemTags {
 
     ItemTag NETHERITE_TIER = create("minecraft:netherite_tier");
 
+    ItemTag FIREPROOF = create("minecraft:fireproof");
+
     ItemTag MUSIC_DISC = create("minecraft:music_disc");
 
     ItemTag HORSE_ARMOR = create("minecraft:horse_armor");

--- a/data/resources/item_tags_custom.json
+++ b/data/resources/item_tags_custom.json
@@ -48,5 +48,23 @@
     "minecraft:enchanted_book",
     "minecraft:writable_book",
     "minecraft:written_book"
+  ],
+  "minecraft:fireproof": [
+    "minecraft:ancient_debris",
+    "minecraft:netherite_axe",
+    "minecraft:netherite_block",
+    "minecraft:netherite_boots",
+    "minecraft:netherite_chestplate",
+    "minecraft:netherite_helmet",
+    "minecraft:netherite_hoe",
+    "minecraft:netherite_horse_armor",
+    "minecraft:netherite_ingot",
+    "minecraft:netherite_leggings",
+    "minecraft:netherite_nautilus_armor",
+    "minecraft:netherite_pickaxe",
+    "minecraft:netherite_scrap",
+    "minecraft:netherite_shovel",
+    "minecraft:netherite_spear",
+    "minecraft:netherite_sword"
   ]
 }

--- a/server/src/main/java/org/allaymc/server/block/component/fire/BlockSoulFireBaseComponentImpl.java
+++ b/server/src/main/java/org/allaymc/server/block/component/fire/BlockSoulFireBaseComponentImpl.java
@@ -11,7 +11,6 @@ import org.allaymc.api.entity.damage.DamageContainer;
 import org.allaymc.api.entity.damage.DamageType;
 import org.allaymc.api.entity.interfaces.EntityLiving;
 import org.allaymc.api.eventbus.event.entity.EntityCombustEvent;
-import org.allaymc.api.eventbus.event.entity.EntityDamageEvent;
 import org.allaymc.server.block.component.BlockBaseComponentImpl;
 
 /**
@@ -42,9 +41,6 @@ public class BlockSoulFireBaseComponentImpl extends BlockBaseComponentImpl {
             living.setOnFireTicks(combustEvent.getOnFireTicks());
         }
 
-        var damageEvent = new EntityDamageEvent(entity, new DamageContainer(block, DamageType.FIRE, 2));
-        if (damageEvent.call()) {
-            living.attack(damageEvent.getDamageContainer());
-        }
+        living.attack(new DamageContainer(block, DamageType.FIRE, 2));
     }
 }

--- a/server/src/main/java/org/allaymc/server/block/component/fire/BlockSoulFireBaseComponentImpl.java
+++ b/server/src/main/java/org/allaymc/server/block/component/fire/BlockSoulFireBaseComponentImpl.java
@@ -1,12 +1,18 @@
 package org.allaymc.server.block.component.fire;
 
-import org.allaymc.server.block.component.BlockBaseComponentImpl;
 import org.allaymc.api.block.BlockBehavior;
 import org.allaymc.api.block.data.BlockFace;
 import org.allaymc.api.block.dto.Block;
+import org.allaymc.api.block.type.BlockState;
 import org.allaymc.api.block.type.BlockType;
 import org.allaymc.api.block.type.BlockTypes;
-import org.allaymc.api.block.type.BlockState;
+import org.allaymc.api.entity.Entity;
+import org.allaymc.api.entity.damage.DamageContainer;
+import org.allaymc.api.entity.damage.DamageType;
+import org.allaymc.api.entity.interfaces.EntityLiving;
+import org.allaymc.api.eventbus.event.entity.EntityCombustEvent;
+import org.allaymc.api.eventbus.event.entity.EntityDamageEvent;
+import org.allaymc.server.block.component.BlockBaseComponentImpl;
 
 /**
  * @author daoge_cmd
@@ -21,6 +27,24 @@ public class BlockSoulFireBaseComponentImpl extends BlockBaseComponentImpl {
         var downBlockType = block.offsetPos(BlockFace.DOWN).getBlockType();
         if (downBlockType != BlockTypes.SOUL_SAND && downBlockType != BlockTypes.SOUL_SOIL) {
             block.getDimension().setBlockState(block.getPosition(), BlockTypes.FIRE.copyPropertyValuesFrom(block.getBlockState()));
+            return;
+        }
+    }
+
+    @Override
+    public void onEntityInside(Block block, Entity entity) {
+        if (!(entity instanceof EntityLiving living)) {
+            return;
+        }
+
+        var combustEvent = new EntityCombustEvent(entity, EntityCombustEvent.CombusterType.BLOCK, block, 20 * 8);
+        if (combustEvent.call()) {
+            living.setOnFireTicks(combustEvent.getOnFireTicks());
+        }
+
+        var damageEvent = new EntityDamageEvent(entity, new DamageContainer(block, DamageType.FIRE, 2));
+        if (damageEvent.call()) {
+            living.attack(damageEvent.getDamageContainer());
         }
     }
 }

--- a/server/src/main/java/org/allaymc/server/block/component/fire/BlockSoulFireBaseComponentImpl.java
+++ b/server/src/main/java/org/allaymc/server/block/component/fire/BlockSoulFireBaseComponentImpl.java
@@ -26,7 +26,6 @@ public class BlockSoulFireBaseComponentImpl extends BlockBaseComponentImpl {
         var downBlockType = block.offsetPos(BlockFace.DOWN).getBlockType();
         if (downBlockType != BlockTypes.SOUL_SAND && downBlockType != BlockTypes.SOUL_SOIL) {
             block.getDimension().setBlockState(block.getPosition(), BlockTypes.FIRE.copyPropertyValuesFrom(block.getBlockState()));
-            return;
         }
     }
 

--- a/server/src/main/java/org/allaymc/server/entity/type/EntityTypeInitializer.java
+++ b/server/src/main/java/org/allaymc/server/entity/type/EntityTypeInitializer.java
@@ -129,11 +129,7 @@ public final class EntityTypeInitializer {
                             }
 
                             var itemType = itemStack.getItemType();
-                            return itemType.hasItemTag(ItemTags.NETHERITE_TIER) ||
-                                   itemType == ItemTypes.ANCIENT_DEBRIS ||
-                                   itemType == ItemTypes.NETHERITE_BLOCK ||
-                                   itemType == ItemTypes.NETHERITE_INGOT ||
-                                   itemType == ItemTypes.NETHERITE_SCRAP;
+                            return itemType.hasItemTag(ItemTags.FIREPROOF);
                         }
 
                         @Override

--- a/server/src/main/java/org/allaymc/server/entity/type/EntityTypeInitializer.java
+++ b/server/src/main/java/org/allaymc/server/entity/type/EntityTypeInitializer.java
@@ -10,7 +10,9 @@ import org.allaymc.api.entity.damage.DamageType;
 import org.allaymc.api.entity.interfaces.EntityAnimal;
 import org.allaymc.api.entity.interfaces.EntityEnderDragon;
 import org.allaymc.api.entity.interfaces.EntityIntelligent;
+import org.allaymc.api.entity.interfaces.EntityItem;
 import org.allaymc.api.entity.interfaces.EntityPlayer;
+import org.allaymc.api.item.data.ItemTags;
 import org.allaymc.api.entity.property.type.EntityPropertyTypes;
 import org.allaymc.api.entity.type.EntityTypes;
 import org.allaymc.api.item.type.ItemTypes;
@@ -113,6 +115,25 @@ public final class EntityTypeInitializer {
                         @Override
                         public boolean hasDrowningDamage() {
                             return false;
+                        }
+
+                        @Override
+                        public boolean isFireproof() {
+                            if (super.isFireproof()) {
+                                return true;
+                            }
+
+                            var itemStack = ((EntityItem) thisEntity).getItemStack();
+                            if (itemStack == null) {
+                                return false;
+                            }
+
+                            var itemType = itemStack.getItemType();
+                            return itemType.hasItemTag(ItemTags.NETHERITE_TIER) ||
+                                   itemType == ItemTypes.ANCIENT_DEBRIS ||
+                                   itemType == ItemTypes.NETHERITE_BLOCK ||
+                                   itemType == ItemTypes.NETHERITE_INGOT ||
+                                   itemType == ItemTypes.NETHERITE_SCRAP;
                         }
 
                         @Override


### PR DESCRIPTION
## Summary
- make soul fire apply vanilla-like burn and stronger contact damage without normal fire spread behavior
- keep dropped netherite-related items fireproof when they exist as item entities
- preserve soul fire fallback to normal fire when the soul block below is removed

## Verification
- ./gradlew :server:compileJava
- ./gradlew :server:shadowJar

Related to https://github.com/AllayMC/Allay/issues/867