### PR TITLE
fix: use proper log4j console type

### DIFF
--- a/server/src/main/resources/log4j2.xml
+++ b/server/src/main/resources/log4j2.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="WARN">
     <Appenders>
-        <Console name="Console" target="SYSTEM_OUT" follow="true">
+        <TerminalConsole name="TerminalConsole">
             <PatternLayout
                     pattern="[%cyan{%d{HH:mm:ss} %level}] [%yellow{%t}] [%blue{%logger{0}}] %minecraftFormatting{%msg}%n"/>
-        </Console>
+        </TerminalConsole>
         <RollingRandomAccessFile name="File" fileName="logs/server.log" filePattern="logs/%d{yyyy-MM-dd}-%i.log.gz">
             <PatternLayout
                     pattern="[%d{HH:mm:ss} %level] [%t] [%logger{0}] %replace{%msg}{§([0-9]|[a|b|c|d|e|f|k|l|o|r])}{}%n"/>
@@ -18,7 +18,7 @@
     </Appenders>
     <Loggers>
         <Root level="INFO">
-            <AppenderRef ref="Console"/>
+            <AppenderRef ref="TerminalConsole"/>
             <AppenderRef ref="File"/>
             <AppenderRef ref="Sentry"/>
         </Root>


### PR DESCRIPTION
Resolves supper annoying bug with prompt line not being persisted when new messages appears in stdout.

Before:
```
[00:45:24 INFO] [main] [AllayServer] Network interface started at 0.0.0.0:19133 (4453 ms)
> say hello[00:48:02 INFO] [Netty Server IO #1] [AllayNetworkInterface] Client connected, IP: /127.0.0.1:48835
[00:48:05 INFO] [Netty Server IO #1] [AllayServer] Client disconnected, IP: /127.0.0.1:48835
[00:48:05 INFO] [Netty Server IO #1] [AllayServer] Zernix2077 left the game
world
[00:48:08 INFO] [Console Thread] [AllayServer] [Server] helloworld
>
```
  
After:
```
[00:51:08 INFO] [main] [AllayServer] Network interface started at 0.0.0.0:19133 (4141 ms)
[00:51:13 INFO] [Netty Server IO #1] [AllayNetworkInterface] Client connected, IP: /127.0.0.1:48835
[00:51:16 INFO] [Netty Server IO #1] [AllayServer] Zernix2077 joined the game
> say hello world
[00:51:18 INFO] [Console Thread] [AllayServer] [Server] hello world
```

This change replaces direct stdout logging, which may affect environments or tools that relied on capturing stdout output. Was it configured like that for specific reason?