### PR TITLE
Hardcode raknetSendCookie

### DIFF
--- a/server/src/main/java/org/allaymc/server/ServerSettings.java
+++ b/server/src/main/java/org/allaymc/server/ServerSettings.java
@@ -137,11 +137,6 @@ public class ServerSettings extends OkaeriConfig {
         @CustomKey("raknet-global-packet-limit")
         private int raknetGlobalPacketLimit = 100000;
 
-        @Comment("Whether to send a cookie to the client during the connection process for additional security")
-        @Comment("Default value is true")
-        @CustomKey("raknet-send-cookie")
-        private boolean raknetSendCookie = true;
-
         @Comment("Maximum allowed MTU that the RakNet server connection can use")
         @Comment("The internet supports a maximum MTU of 1492 but could cause issues with packet fragmentation.")
         @Comment("Default value is 1400")

--- a/server/src/main/java/org/allaymc/server/network/AllayRakNetInterface.java
+++ b/server/src/main/java/org/allaymc/server/network/AllayRakNetInterface.java
@@ -108,7 +108,7 @@ public class AllayRakNetInterface extends AllayNetworkInterface {
                 .channelFactory(RakChannelFactory.server(datagramChannelClass))
                 .option(RakChannelOption.RAK_ADVERTISEMENT, pong.toByteBuf())
                 // I think we don't need other modes
-                .option(RakChannelOption.RAK_SERVER_COOKIE_MODE, networkSettings.raknetSendCookie() ? RakServerCookieMode.ACTIVE : RakServerCookieMode.OFF)
+                .option(RakChannelOption.RAK_SERVER_COOKIE_MODE, RakServerCookieMode.ACTIVE)
                 .option(RakChannelOption.RAK_MAX_MTU, networkSettings.raknetMaxMtu())
                 .option(RakChannelOption.RAK_GUID, serverId)
                 // Integer.MAX_VALUE fixed localhost blocking address


### PR DESCRIPTION
due to [thiscommit](https://github.com/CloudburstMC/Network/commit/8cc223f457a67bba2fc3df06d48c271c135af866)
we can't detect the raknet version when disable the raknetSendCookie
we need to detect raknet version so we can support NetEase version of the game