### PR TITLE
feat: introduce PotionSplashEvent

### DIFF
--- a/api/src/main/java/org/allaymc/api/eventbus/event/entity/PotionSplashEvent.java
+++ b/api/src/main/java/org/allaymc/api/eventbus/event/entity/PotionSplashEvent.java
@@ -1,0 +1,33 @@
+package org.allaymc.api.eventbus.event.entity;
+
+import lombok.Getter;
+import org.allaymc.api.annotation.CallerThread;
+import org.allaymc.api.annotation.ThreadType;
+import org.allaymc.api.entity.interfaces.EntityLiving;
+import org.allaymc.api.entity.interfaces.EntitySplashPotion;
+import org.allaymc.api.eventbus.event.CancellableEvent;
+
+/**
+ * Called before a splash potion applies effects to a target entity.
+ *
+ * @author zernix2077
+ */
+@Getter
+@CallerThread(ThreadType.DIMENSION)
+public class PotionSplashEvent extends EntityEvent implements CancellableEvent {
+
+    /**
+     * The target entity that would receive splash potion effects.
+     */
+    protected EntityLiving target;
+
+    public PotionSplashEvent(EntitySplashPotion splashPotion, EntityLiving target) {
+        super(splashPotion);
+        this.target = target;
+    }
+
+    @Override
+    public EntitySplashPotion getEntity() {
+        return (EntitySplashPotion) super.getEntity();
+    }
+}

--- a/server/src/main/java/org/allaymc/server/entity/component/projectile/EntityPotionPhysicsComponentImpl.java
+++ b/server/src/main/java/org/allaymc/server/entity/component/projectile/EntityPotionPhysicsComponentImpl.java
@@ -7,6 +7,8 @@ import org.allaymc.api.block.dto.Block;
 import org.allaymc.api.entity.Entity;
 import org.allaymc.api.entity.component.EntityPotionComponent;
 import org.allaymc.api.entity.interfaces.EntityLiving;
+import org.allaymc.api.entity.interfaces.EntitySplashPotion;
+import org.allaymc.api.eventbus.event.entity.PotionSplashEvent;
 import org.allaymc.api.item.data.PotionType;
 import org.allaymc.api.math.MathUtils;
 import org.allaymc.api.math.position.Position3i;
@@ -92,6 +94,14 @@ public abstract class EntityPotionPhysicsComponentImpl extends EntityProjectileP
                 }
 
                 var factor = living != entityBeingHit ? 1.0 - distance / 4.0 : 1.0;
+
+                if (thisEntity instanceof EntitySplashPotion splashPotion) {
+                    var event = new PotionSplashEvent(splashPotion, living);
+                    if (!event.call()) {
+                        continue;
+                    }
+                }
+
                 for (var effect : effects) {
                     // Instant effects (duration <= 1) should not have duration modified
                     if (effect.getDuration() > 1) {


### PR DESCRIPTION
this event allows to selectively cancel or handle splash potion effect application for each player, even when multiple entities are within splash range