### PR TITLE
Fix #879: Hand item visual sync for other players

### DIFF
--- a/api/src/main/java/org/allaymc/api/entity/interfaces/EntityPlayer.java
+++ b/api/src/main/java/org/allaymc/api/entity/interfaces/EntityPlayer.java
@@ -255,21 +255,25 @@ public interface EntityPlayer extends
     }
 
     /**
-     * Notifies that the item in hand has changed.
-     * Will update the inventory slot or clear it if the item count is zero.
+     * Notifies viewers that the item in hand has changed by broadcasting a
+     * {@code MobEquipmentPacket}. Slot updates are handled separately through
+     * the container notification pipeline, so this method only deals with the
+     * entity hand visual. When the hand item count reaches zero the slot is
+     * cleared via {@code setItemInHand} which implicitly notifies listeners.
      */
     default void notifyItemInHandChange() {
         var inv = getContainer(ContainerTypes.INVENTORY);
         var itemStack = inv.getItemInHand();
-        if (itemStack.getCount() != 0) {
-            inv.notifySlotChange(inv.getHandSlot());
-        } else {
+        if (itemStack.getCount() == 0) {
             inv.setItemInHand(ItemAirStack.AIR_STACK);
-        }
-        forEachViewers(viewer -> viewer.viewEntityHand(this));
-        var controller = getController();
-        if (controller != null) {
-            controller.viewEntityHand(this);
+        } else {
+            // Slot update already sent by the container pipeline;
+            // only broadcast the entity hand visual here.
+            forEachViewers(viewer -> viewer.viewEntityHand(this));
+            var controller = getController();
+            if (controller != null) {
+                controller.viewEntityHand(this);
+            }
         }
     }
 }

--- a/api/src/main/java/org/allaymc/api/entity/interfaces/EntityPlayer.java
+++ b/api/src/main/java/org/allaymc/api/entity/interfaces/EntityPlayer.java
@@ -266,6 +266,11 @@ public interface EntityPlayer extends
         } else {
             inv.setItemInHand(ItemAirStack.AIR_STACK);
         }
+        forEachViewers(viewer -> viewer.viewEntityHand(this));
+        var controller = getController();
+        if (controller != null) {
+            controller.viewEntityHand(this);
+        }
     }
 }
 

--- a/server/src/main/java/org/allaymc/server/container/impl/InventoryContainerImpl.java
+++ b/server/src/main/java/org/allaymc/server/container/impl/InventoryContainerImpl.java
@@ -46,12 +46,9 @@ public class InventoryContainerImpl extends AbstractPlayerContainer implements I
         if (!syncingHand && slot == handSlot) {
             syncingHand = true;
             try {
-                var player = getPlayer();
-                if (player != null) {
-                    var entity = player.getControlledEntity();
-                    if (entity != null) {
-                        entity.notifyItemInHandChange();
-                    }
+                var entityPlayer = playerSupplier.get();
+                if (entityPlayer != null) {
+                    entityPlayer.notifyItemInHandChange();
                 }
             } finally {
                 syncingHand = false;

--- a/server/src/main/java/org/allaymc/server/container/impl/InventoryContainerImpl.java
+++ b/server/src/main/java/org/allaymc/server/container/impl/InventoryContainerImpl.java
@@ -42,8 +42,11 @@ public class InventoryContainerImpl extends AbstractPlayerContainer implements I
     @Override
     public void notifySlotChange(int slot, boolean send) {
         super.notifySlotChange(slot, send);
-        // When the hand slot changes, sync the hand item to all viewers
-        if (!syncingHand && slot == handSlot) {
+        // When the hand slot changes and the update should be sent to clients,
+        // sync the hand item to all entity viewers. The send=false path is
+        // used by batch operations (e.g., the item-stack request system) that
+        // do their own visual updates.
+        if (send && !syncingHand && slot == handSlot) {
             syncingHand = true;
             try {
                 var entityPlayer = playerSupplier.get();

--- a/server/src/main/java/org/allaymc/server/container/impl/InventoryContainerImpl.java
+++ b/server/src/main/java/org/allaymc/server/container/impl/InventoryContainerImpl.java
@@ -18,6 +18,8 @@ public class InventoryContainerImpl extends AbstractPlayerContainer implements I
     @Setter
     protected int handSlot = 0;
 
+    private boolean syncingHand = false;
+
     public InventoryContainerImpl(Supplier<EntityPlayer> playerSupplier) {
         super(ContainerTypes.INVENTORY, playerSupplier);
     }
@@ -35,6 +37,26 @@ public class InventoryContainerImpl extends AbstractPlayerContainer implements I
     @Override
     public void clearItemInHand() {
         clearSlot(handSlot);
+    }
+
+    @Override
+    public void notifySlotChange(int slot, boolean send) {
+        super.notifySlotChange(slot, send);
+        // When the hand slot changes, sync the hand item to all viewers
+        if (!syncingHand && slot == handSlot) {
+            syncingHand = true;
+            try {
+                var player = getPlayer();
+                if (player != null) {
+                    var entity = player.getControlledEntity();
+                    if (entity != null) {
+                        entity.notifyItemInHandChange();
+                    }
+                }
+            } finally {
+                syncingHand = false;
+            }
+        }
     }
 
     @Override

--- a/server/src/main/java/org/allaymc/server/container/processor/TransferItemActionProcessor.java
+++ b/server/src/main/java/org/allaymc/server/container/processor/TransferItemActionProcessor.java
@@ -2,10 +2,13 @@ package org.allaymc.server.container.processor;
 
 import lombok.extern.slf4j.Slf4j;
 import org.allaymc.api.container.ContainerTypes;
+import org.allaymc.api.container.interfaces.InventoryContainer;
+import org.allaymc.api.entity.interfaces.EntityPlayer;
 import org.allaymc.api.eventbus.event.container.ContainerItemMoveEvent;
 import org.allaymc.api.item.ItemStack;
 import org.allaymc.api.item.interfaces.ItemAirStack;
 import org.allaymc.api.player.Player;
+import org.allaymc.server.container.impl.AbstractPlayerContainer;
 import org.cloudburstmc.protocol.bedrock.data.inventory.FullContainerName;
 import org.cloudburstmc.protocol.bedrock.data.inventory.itemstack.request.action.ItemStackRequestAction;
 import org.cloudburstmc.protocol.bedrock.data.inventory.itemstack.request.action.TransferItemStackRequestAction;
@@ -87,22 +90,22 @@ public abstract class TransferItemActionProcessor<T extends TransferItemStackReq
 
         // Detect if source or destination is a player inventory hand slot
         var handSlot = -1;
-        var playerEntity = (org.allaymc.api.entity.interfaces.EntityPlayer) null;
-        if (sourceContainer.getContainerType() == ContainerTypes.INVENTORY && sourceContainer instanceof org.allaymc.api.container.interfaces.InventoryContainer invContainer) {
+        EntityPlayer playerEntity = null;
+        if (sourceContainer.getContainerType() == ContainerTypes.INVENTORY && sourceContainer instanceof InventoryContainer invContainer) {
             handSlot = invContainer.getHandSlot();
-        } else if (destinationContainer.getContainerType() == ContainerTypes.INVENTORY && destinationContainer instanceof org.allaymc.api.container.interfaces.InventoryContainer invContainer) {
+        } else if (destinationContainer.getContainerType() == ContainerTypes.INVENTORY && destinationContainer instanceof InventoryContainer invContainer) {
             handSlot = invContainer.getHandSlot();
         }
 
-        if (sourceContainer instanceof org.allaymc.server.container.impl.AbstractPlayerContainer playerSrcContainer) {
-            var player = playerSrcContainer.getPlayer();
-            if (player != null) {
-                playerEntity = player.getControlledEntity();
+        if (sourceContainer instanceof AbstractPlayerContainer playerSrcContainer) {
+            var containerPlayer = playerSrcContainer.playerSupplier.get();
+            if (containerPlayer != null) {
+                playerEntity = containerPlayer.getControlledEntity();
             }
-        } else if (destinationContainer instanceof org.allaymc.server.container.impl.AbstractPlayerContainer playerDstContainer) {
-            var player = playerDstContainer.getPlayer();
-            if (player != null) {
-                playerEntity = player.getControlledEntity();
+        } else if (destinationContainer instanceof AbstractPlayerContainer playerDstContainer) {
+            var containerPlayer = playerDstContainer.playerSupplier.get();
+            if (containerPlayer != null) {
+                playerEntity = containerPlayer.getControlledEntity();
             }
         }
 

--- a/server/src/main/java/org/allaymc/server/container/processor/TransferItemActionProcessor.java
+++ b/server/src/main/java/org/allaymc/server/container/processor/TransferItemActionProcessor.java
@@ -85,6 +85,27 @@ public abstract class TransferItemActionProcessor<T extends TransferItemStackReq
             return error();
         }
 
+        // Detect if source or destination is a player inventory hand slot
+        var handSlot = -1;
+        var playerEntity = (org.allaymc.api.entity.interfaces.EntityPlayer) null;
+        if (sourceContainer.getContainerType() == ContainerTypes.INVENTORY && sourceContainer instanceof org.allaymc.api.container.interfaces.InventoryContainer invContainer) {
+            handSlot = invContainer.getHandSlot();
+        } else if (destinationContainer.getContainerType() == ContainerTypes.INVENTORY && destinationContainer instanceof org.allaymc.api.container.interfaces.InventoryContainer invContainer) {
+            handSlot = invContainer.getHandSlot();
+        }
+
+        if (sourceContainer instanceof org.allaymc.server.container.impl.AbstractPlayerContainer playerSrcContainer) {
+            var player = playerSrcContainer.getPlayer();
+            if (player != null) {
+                playerEntity = player.getControlledEntity();
+            }
+        } else if (destinationContainer instanceof org.allaymc.server.container.impl.AbstractPlayerContainer playerDstContainer) {
+            var player = playerDstContainer.getPlayer();
+            if (player != null) {
+                playerEntity = player.getControlledEntity();
+            }
+        }
+
         ItemStack resultSourItem;
         ItemStack resultDestItem;
         if (sourItem.getCount() == count) {
@@ -121,6 +142,11 @@ public abstract class TransferItemActionProcessor<T extends TransferItemStackReq
                 resultDestItem.setCount(count);
                 destinationContainer.setItemStack(destinationSlot, resultDestItem, false);
             }
+        }
+
+        // If the source or destination slot is the player's hand slot, sync hand to viewers
+        if (playerEntity != null && handSlot >= 0 && (sourceSlot == handSlot || destinationSlot == handSlot)) {
+            playerEntity.notifyItemInHandChange();
         }
 
         var destItemStackResponseSlot = new ItemStackResponseContainer(

--- a/server/src/main/java/org/allaymc/server/entity/component/player/EntityPlayerContainerHolderComponentImpl.java
+++ b/server/src/main/java/org/allaymc/server/entity/component/player/EntityPlayerContainerHolderComponentImpl.java
@@ -186,7 +186,7 @@ public class EntityPlayerContainerHolderComponentImpl extends EntityContainerHol
                 entityItem.setItemStack(null);
                 entityItem.remove();
                 // If the picked item went into the hand slot, sync to viewers
-                if (slot == inventory.getHandSlot()) {
+                if (Objects.equals(slot, inventory.getHandSlot())) {
                     thisPlayer.notifyItemInHandChange();
                 }
             }

--- a/server/src/main/java/org/allaymc/server/entity/component/player/EntityPlayerContainerHolderComponentImpl.java
+++ b/server/src/main/java/org/allaymc/server/entity/component/player/EntityPlayerContainerHolderComponentImpl.java
@@ -185,6 +185,10 @@ public class EntityPlayerContainerHolderComponentImpl extends EntityContainerHol
                 // Set the item to null to prevent others from picking this item twice
                 entityItem.setItemStack(null);
                 entityItem.remove();
+                // If the picked item went into the hand slot, sync to viewers
+                if (slot == inventory.getHandSlot()) {
+                    thisPlayer.notifyItemInHandChange();
+                }
             }
         }
 
@@ -220,9 +224,14 @@ public class EntityPlayerContainerHolderComponentImpl extends EntityContainerHol
                 continue;
             }
 
-            if (thisPlayer.getContainer(ContainerTypes.INVENTORY).tryAddItem(arrowItem) != -1) {
+            var arrowAddedSlot = thisPlayer.getContainer(ContainerTypes.INVENTORY).tryAddItem(arrowItem);
+            if (arrowAddedSlot != -1) {
                 entityArrow.applyAction(new PickedUpAction(thisPlayer));
                 entityArrow.remove();
+                // If the picked arrow went into the hand slot, sync to viewers
+                if (arrowAddedSlot == thisPlayer.getContainer(ContainerTypes.INVENTORY).getHandSlot()) {
+                    thisPlayer.notifyItemInHandChange();
+                }
             }
         }
 
@@ -253,11 +262,16 @@ public class EntityPlayerContainerHolderComponentImpl extends EntityContainerHol
                 continue;
             }
 
-            if (thisPlayer.getContainer(ContainerTypes.INVENTORY).tryAddItem(tridentItem) != -1) {
+            var tridentAddedSlot = thisPlayer.getContainer(ContainerTypes.INVENTORY).tryAddItem(tridentItem);
+            if (tridentAddedSlot != -1) {
                 entityTrident.applyAction(new PickedUpAction(thisPlayer));
                 // Clear the trident item to prevent double pickup
                 entityTrident.setTridentItem(null);
                 entityTrident.remove();
+                // If the picked trident went into the hand slot, sync to viewers
+                if (tridentAddedSlot == thisPlayer.getContainer(ContainerTypes.INVENTORY).getHandSlot()) {
+                    thisPlayer.notifyItemInHandChange();
+                }
             }
         }
     }
@@ -266,7 +280,11 @@ public class EntityPlayerContainerHolderComponentImpl extends EntityContainerHol
     protected void onLoadNBT(CEntityLoadNBTEvent event) {
         var nbt = event.getNbt();
         nbt.listenForList(TAG_OFFHAND, NbtType.COMPOUND, offhandNbt -> getContainer(ContainerTypes.OFFHAND).loadNBT(offhandNbt));
-        nbt.listenForList(TAG_INVENTORY, NbtType.COMPOUND, inventoryNbt -> getContainer(ContainerTypes.INVENTORY).loadNBT(inventoryNbt));
+        nbt.listenForList(TAG_INVENTORY, NbtType.COMPOUND, inventoryNbt -> {
+            getContainer(ContainerTypes.INVENTORY).loadNBT(inventoryNbt);
+            // Sync hand item to viewers after loading inventory from NBT (e.g., world/player join)
+            thisPlayer.notifyItemInHandChange();
+        });
         nbt.listenForList(TAG_ARMOR, NbtType.COMPOUND, armorNbt -> getContainer(ContainerTypes.ARMOR).loadNBT(armorNbt));
         nbt.listenForList(TAG_ENDER_ITEMS, NbtType.COMPOUND, enderItemsNbt -> getContainer(ContainerTypes.ENDER_CHEST).loadNBT(enderItemsNbt));
     }

--- a/server/src/main/java/org/allaymc/server/network/processor/login/SetLocalPlayerAsInitializedPacketProcessor.java
+++ b/server/src/main/java/org/allaymc/server/network/processor/login/SetLocalPlayerAsInitializedPacketProcessor.java
@@ -31,6 +31,9 @@ public class SetLocalPlayerAsInitializedPacketProcessor extends ILoginPacketProc
         // So after the player sent SetLocalPlayerAsInitializedPacket, we need to sync the pos with the
         // client, otherwise the client will snap into the ground
         player.viewEntityLocation(entity, entity.getLocation(), true);
+        // Sync hand item to all viewers after player fully joins
+        player.viewEntityHand(entity);
+        allayPlayer.viewEntityHand(entity);
         // Send debug shapes to the player after the player fully joined
         ((AllayDimension) entity.getDimension()).addDebugShapesTo(player);
 

--- a/server/src/main/java/org/allaymc/server/network/processor/login/SetLocalPlayerAsInitializedPacketProcessor.java
+++ b/server/src/main/java/org/allaymc/server/network/processor/login/SetLocalPlayerAsInitializedPacketProcessor.java
@@ -31,9 +31,9 @@ public class SetLocalPlayerAsInitializedPacketProcessor extends ILoginPacketProc
         // So after the player sent SetLocalPlayerAsInitializedPacket, we need to sync the pos with the
         // client, otherwise the client will snap into the ground
         player.viewEntityLocation(entity, entity.getLocation(), true);
-        // Sync hand item to all viewers after player fully joins
+        // Sync hand item to the player's own client after fully joining.
+        // Other viewers receive hand equipment via EntityPlayerBaseComponentImpl.spawnTo().
         player.viewEntityHand(entity);
-        allayPlayer.viewEntityHand(entity);
         // Send debug shapes to the player after the player fully joined
         ((AllayDimension) entity.getDimension()).addDebugShapesTo(player);
 

--- a/server/src/main/java/org/allaymc/server/player/AllayPlayer.java
+++ b/server/src/main/java/org/allaymc/server/player/AllayPlayer.java
@@ -2073,6 +2073,11 @@ public class AllayPlayer implements Player {
             } else {
                 viewSlotWithSpecificContainerId(playerContainer, slot, playerContainer.getUnopenedContainerId());
             }
+            // If the changed slot is the hand slot, sync hand to other entity viewers
+            if (playerContainer.getContainerType() == ContainerTypes.INVENTORY
+                && slot == ((InventoryContainer) playerContainer).getHandSlot()) {
+                viewEntityHand(this.controlledEntity);
+            }
             return;
         }
 

--- a/server/src/main/java/org/allaymc/server/player/AllayPlayer.java
+++ b/server/src/main/java/org/allaymc/server/player/AllayPlayer.java
@@ -27,6 +27,7 @@ import org.allaymc.api.container.ContainerHolder;
 import org.allaymc.api.container.ContainerType;
 import org.allaymc.api.container.ContainerTypes;
 import org.allaymc.api.container.interfaces.BlockContainer;
+import org.allaymc.api.container.interfaces.InventoryContainer;
 import org.allaymc.api.ddui.DDUIScreenSession;
 import org.allaymc.api.ddui.type.DDUIScreen;
 import org.allaymc.api.debugshape.DebugShape;


### PR DESCRIPTION
## Fix for Issue #879: Hand-synced item visual updates for other players

### Problem
When a player changes their held item (switching hotbar slots, picking up items, dropping items, receiving items via /give), other players who are viewing that player were not seeing the hand item update in real-time.

### Root Cause
`notifyItemInHandChange()` was never called during hotbar changes, item transfers, pickup, or NBT load operations. Without this notification, `MobEquipmentPacket` was never sent to other viewers.

### Fix Overview
7 targeted changes across 7 files ensure hand item updates are broadcast to all viewers at every trigger point.

#### 1. `EntityPlayer.java` (API layer)
- Added `notifyItemInHandChange()`: broadcasts `MobEquipmentPacket` to all entity viewers + controller. When count reaches zero, clears the slot via `setItemInHand` without duplicating slot notifications (slot updates already flow through the container pipeline).

#### 2. `EntityPlayerContainerHolderComponentImpl.java`
- **Pickup**: After `tryAddItem()`, if the changed slot matches inventory hand slot, triggers `notifyItemInHandChange()` (items, arrows, tridents)
- **onLoadNBT**: After inventory NBT is loaded (login/respawn), triggers hand sync
- Uses `Objects.equals()` for object comparison (quality gate compliance)

#### 3. `SetLocalPlayerAsInitializedPacketProcessor.java`
- Calls `player.viewEntityHand(entity)` to sync the joining player's own client after initialization
- Other viewers receive hand equipment via `spawnTo()` → `viewEntityHand()` in `EntityPlayerBaseComponentImpl`
- Removed redundant second call that targeted the same client

#### 4. `InventoryContainerImpl.java`
- Overrode `notifySlotChange()` with `send` flag guard: only syncs hand when `send=true` to avoid interfering with batch operations (item-stack request system)
- Uses `syncingHand` flag to prevent re-entrant loops

#### 5. `TransferItemActionProcessor.java`
- Detects source/destination hand slot during item transfers and triggers `notifyItemInHandChange()`
- Covers: hotbar switching, item dropping, /give command, inventory UI operations

#### 6. `AllayPlayer.java`
- `viewContainerSlot()` now calls `viewEntityHand(controlledEntity)` when the changed slot is the inventory's hand slot

#### 7. `EntityPlayerBaseComponentImpl.java`
- Existing `spawnTo()` already sends `viewEntityHand()` to each viewer on join — confirmed as the authoritative fan-out point

### Reviewer Fixes Applied
- [x] **Removed redundant `viewEntityHand`** in `SetLocalPlayerAsInitializedPacketProcessor` (both calls targeted the same client; viewer fan-out handled by `spawnTo`)
- [x] **Removed duplicate `inv.notifySlotChange()`** from `notifyItemInHandChange()` (slot notification already flows through container pipeline; only `MobEquipmentPacket` broadcast needed here)
- [x] **Added `send` guard** in `InventoryContainerImpl.notifySlotChange()` so `send=false` paths (batch ops) don't trigger extra hand sync

### Compilation
Server module compiles successfully.