### PR TITLE
fix: item hand desync

### DIFF
--- a/server/src/main/java/org/allaymc/server/container/impl/InventoryContainerImpl.java
+++ b/server/src/main/java/org/allaymc/server/container/impl/InventoryContainerImpl.java
@@ -38,6 +38,17 @@ public class InventoryContainerImpl extends AbstractPlayerContainer implements I
     }
 
     @Override
+    public void notifySlotChange(int slot, boolean send) {
+        super.notifySlotChange(slot, send);
+        if (slot == handSlot) {
+            var player = playerSupplier.get();
+            if (player != null) {
+                player.forEachViewers(viewer -> viewer.viewEntityHand(player));
+            }
+        }
+    }
+
+    @Override
     public int getUnopenedContainerId() {
         return UnopenedContainerId.PLAYER_INVENTORY;
     }

--- a/server/src/main/java/org/allaymc/server/player/AllayPlayer.java
+++ b/server/src/main/java/org/allaymc/server/player/AllayPlayer.java
@@ -387,6 +387,12 @@ public class AllayPlayer implements Player {
         viewPlayerPermission(this);
         viewPlayerListChange(playerManager.getPlayers().values(), true);
 
+        this.controlledEntity.forEachViewers(viewer -> {
+            viewer.viewEntityArmors(this.controlledEntity);
+            viewer.viewEntityHand(this.controlledEntity);
+            viewer.viewEntityOffhand(this.controlledEntity);
+        });
+
         sendSpeed(this.speed);
         sendExperienceLevel(this.controlledEntity.getExperienceLevel());
         sendExperienceProgress(this.controlledEntity.getExperienceProgress());


### PR DESCRIPTION
calls viewEntityHand upon hand slot inventory update and ensures equipment packets are sent after nbt loads after join
seems to cover all hand slot update cases, like dropping, moving in inventory, consuming, picking up, etc.