### PR TITLE
fix: ensure inventory sync after drop cancellation

### DIFF
--- a/api/src/main/java/org/allaymc/api/entity/interfaces/EntityPlayer.java
+++ b/api/src/main/java/org/allaymc/api/entity/interfaces/EntityPlayer.java
@@ -122,6 +122,7 @@ public interface EntityPlayer extends
         var item = container.getItemStack(slot);
         var event = new PlayerDropItemEvent(this, item);
         if (!event.call()) {
+            container.notifySlotChange(slot);
             return;
         }
 


### PR DESCRIPTION
sync player inventory when PlayerDropItemEvent is cancelled instead of leaving client in desynced state