### PR TITLE
feat: send-movement-speed-updates server option

### DIFF
--- a/server/src/main/java/org/allaymc/server/ServerSettings.java
+++ b/server/src/main/java/org/allaymc/server/ServerSettings.java
@@ -119,6 +119,12 @@ public class ServerSettings extends OkaeriConfig {
         @CustomKey("compression-algorithm")
         private CompressionAlgorithm compressionAlgorithm = CompressionAlgorithm.ZLIB;
 
+        @Comment("Sending movement speed updates during actions such as sprinting or using speed or slowness effects may interfere with the client's prediction")
+        @Comment("The client correctly predicts movement speed locally in all standard cases, and additional server-side updates may lead to inconsistent speed states")
+        @Comment("Disabling this may make client-side movement speed more deterministic and predictable, but may cause desynchronization if the speed attribute is updated manually by the plugin")
+        @CustomKey("send-movement-speed-updates")
+        private boolean sendMovementSpeedUpdates = true;
+
         @CustomKey("network-thread-number")
         @Comment("The number of network threads. If put zero here, the server will automatically determine the number of network threads")
         private int networkThreadNumber = 0;

--- a/server/src/main/java/org/allaymc/server/player/AllayPlayer.java
+++ b/server/src/main/java/org/allaymc/server/player/AllayPlayer.java
@@ -3362,7 +3362,11 @@ public class AllayPlayer implements Player {
     public void setSpeed(Speed speed) {
         if (!this.speed.equals(speed)) {
             this.speed = speed;
-            sendSpeed(this.speed);
+
+            // NOTE: Sending speed updates to the client may interfere with local movement speed prediction
+            if (AllayServer.getSettings().networkSettings().sendMovementSpeedUpdates()) {
+                sendSpeed(this.speed);
+            }
         }
     }
 


### PR DESCRIPTION
I stumbled upon some very strange client behavior while developing a movement anticheat: when a player starts sprinting, the client can experience up to 3 movement speed changes over a span of up to 10 ticks, especially during sprint key jittering or movement-affecting effect updates. in some cases, client even ends up in movement speeds that should be impossible under normal circumstances. e.g., the client may multiply the base movement speed of `0.1` by `1.3`, while the server also updates the movement speed to `0.13`, but sometimes the server applies `0.13` first, and then the client multiplies it again, resulting in `0.169`. the number of these inconsistencies increases even further when speed-affecting effects are involved.
everything became perfectly consistent once the server stopped sending movement speed updates and the client moved in a completely predictable and deterministic manner.
it appears that clients starting from 1.21.60 are fully capable of predicting movement speed locally, including sprinting and potion effects, and in these cases, server-side movement speed updates only introduce inconsistencies.
for users like me, who care about these details and do not modify players' movement speed to non-standard values on the server, I propose adding a `send-movement-speed-updates` server option, defaulting to `true`.
