### PR TITLE
fix: prevent creative item usage without opening inventory first

### DIFF
--- a/server/src/main/java/org/allaymc/server/container/processor/CraftCreativeActionProcessor.java
+++ b/server/src/main/java/org/allaymc/server/container/processor/CraftCreativeActionProcessor.java
@@ -23,6 +23,11 @@ public class CraftCreativeActionProcessor implements ContainerActionProcessor<Cr
             return error();
         }
 
+        if (player.getOpenedContainer(ContainerTypes.INVENTORY) == null) {
+            log.warn("Player {} tried to take creative item without opening inventory", player.getOriginName());
+            return error();
+        }
+
         // NOTICE: 0 is not indexed by the client for items
         var item = Registries.CREATIVE_ITEMS.getEntryByIndex(action.creativeItemNetworkId() - 1).itemStack();
         if (item == null) {


### PR DESCRIPTION
this way plugin can simply cancel inventory open and block pick requests for players in creative mode, and there would be no way for them to obtain any blocks, even when using hacked client functions like horion `.give`.