### PR TITLE
chores: update server .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,10 @@
 /server/players
 /server/plugins
 /server/resource_packs
-/server/server-settings.yml
 /server/worlds
 /server/ban-info.yml
+/server/biome-ids.yml
+/server/dimension-ids.yml
+/server/operators.yml
+/server/server-settings.yml
 /server/whitelist.yml


### PR DESCRIPTION
some server folders produced from gradle run task where not in `.gitignore`.
but gradle shadowRun task already uses `.run` folder. maybe run task should too? 