### PR TITLE
feat: trace mode

### DIFF
--- a/server/src/main/java/org/allaymc/server/AllayServer.java
+++ b/server/src/main/java/org/allaymc/server/AllayServer.java
@@ -163,8 +163,11 @@ public final class AllayServer implements Server {
         var ctx = (LoggerContext) LogManager.getContext(false);
         var log4jConfig = ctx.getConfiguration();
         var loggerConfig = log4jConfig.getLoggerConfig(LogManager.ROOT_LOGGER_NAME);
-        if (SETTINGS.genericSettings().debug() && Level.TRACE.isLessSpecificThan(loggerConfig.getLevel())) {
-            loggerConfig.setLevel(Level.TRACE);
+        if (
+                SETTINGS.genericSettings().debug() && Level.DEBUG.isLessSpecificThan(loggerConfig.getLevel()) ||
+                        SETTINGS.genericSettings().trace() && Level.TRACE.isLessSpecificThan(loggerConfig.getLevel())
+        ) {
+            loggerConfig.setLevel(SETTINGS.genericSettings().debug() ? Level.DEBUG : Level.TRACE);
             ctx.updateLoggers();
         }
 

--- a/server/src/main/java/org/allaymc/server/ServerSettings.java
+++ b/server/src/main/java/org/allaymc/server/ServerSettings.java
@@ -71,6 +71,10 @@ public class ServerSettings extends OkaeriConfig {
         @Comment("If debug mode is enabled, the console will output more detailed information")
         private boolean debug = false;
 
+        @Comment("If trace mode is enabled, the console will output even more detailed information,")
+        @Comment("including packets received by all players, possibly producing a lot of unwanted spam")
+        private boolean trace = false;
+
         @Comment("If whitelist is enabled, only players in the whitelist can join the server")
         @CustomKey("enable-whitelist")
         private boolean enableWhitelist = false;

--- a/server/src/main/java/org/allaymc/server/network/AllayNetworkInterface.java
+++ b/server/src/main/java/org/allaymc/server/network/AllayNetworkInterface.java
@@ -110,8 +110,8 @@ public abstract class AllayNetworkInterface implements NetworkInterface {
             return;
         }
 
-        // Enable detailed packet logging if debug mode is enabled
-        if (AllayServer.getSettings().genericSettings().debug()) {
+        // Enable detailed packet logging if trace mode is enabled
+        if (AllayServer.getSettings().genericSettings().trace()) {
             session.setLogging(true);
         }
 


### PR DESCRIPTION
previously the server `debug` option enabled log4j trace logging and session packet logging, which produced an overwhelming amount of terminal output. this behavior has been moved to a separate `trace` option, while `debug` now uses the actual log4j debug level, making server `log.debug` messages visible.
