### PR TITLE
fix: container edge cases handling

### DIFF
--- a/server/src/main/java/org/allaymc/server/container/impl/BaseContainer.java
+++ b/server/src/main/java/org/allaymc/server/container/impl/BaseContainer.java
@@ -87,9 +87,7 @@ public class BaseContainer implements Container {
     @Override
     public boolean addViewer(ContainerViewer viewer) {
         if (viewers.containsValue(viewer)) {
-            log.warn("Viewer already exists! Container: {}, Viewer: {}", this.containerType, viewer);
-            removeViewer(viewer);
-            return addViewer(viewer);
+            return true;
         }
         if (viewer instanceof Player player && this instanceof BlockContainer && !player.canOpenContainers()) {
             return false;

--- a/server/src/main/java/org/allaymc/server/container/impl/DoubleChestContainerImpl.java
+++ b/server/src/main/java/org/allaymc/server/container/impl/DoubleChestContainerImpl.java
@@ -190,9 +190,7 @@ public class DoubleChestContainerImpl implements BlockContainer {
     @Override
     public boolean addViewer(ContainerViewer viewer) {
         if (viewers.containsValue(viewer)) {
-            log.warn("Viewer already exists! Container: {}, Viewer: {}", getContainerType(), viewer);
-            removeViewer(viewer);
-            return addViewer(viewer);
+            return true;
         }
         if (viewer instanceof Player player && !player.canOpenContainers()) {
             return false;

--- a/server/src/main/java/org/allaymc/server/network/processor/ingame/ContainerClosePacketProcessor.java
+++ b/server/src/main/java/org/allaymc/server/network/processor/ingame/ContainerClosePacketProcessor.java
@@ -1,6 +1,6 @@
 package org.allaymc.server.network.processor.ingame;
 
-import lombok.extern.slf4j.Slf4j;
+import org.allaymc.api.container.ContainerTypes;
 import org.allaymc.api.player.Player;
 import org.allaymc.server.network.processor.PacketProcessor;
 import org.allaymc.server.player.AllayPlayer;
@@ -10,12 +10,30 @@ import org.cloudburstmc.protocol.bedrock.packet.ContainerClosePacket;
 /**
  * @author Cool_Loong | daoge_cmd
  */
-@Slf4j
 public class ContainerClosePacketProcessor extends PacketProcessor<ContainerClosePacket> {
 
     @Override
     public void handleSync(Player player, ContainerClosePacket packet, long receiveTime) {
         var opened = player.getOpenedContainer(packet.getId());
+        var suppressCloseResponse = false;
+
+        // In edge cases, such as opening the chat at the exact moment a container is opened,
+        // the client sends a container-close packet with an id of -1, which means that any
+        // currently open container should be closed.
+        if (opened == null && packet.getId() == -1) {
+            opened = player.getOpenedContainer(ContainerTypes.INVENTORY);
+            if (opened != null) {
+                suppressCloseResponse = true;
+            } else if (!player.getOpenedContainers().isEmpty()) {
+                var allayPlayer = (AllayPlayer) player;
+                for (var container : player.getOpenedContainers()) {
+                    allayPlayer.setSuppressNextContainerClosePacket(true);
+                    container.removeViewer(player);
+                }
+                return;
+            }
+        }
+
         if (opened == null) {
             // This may be a container closed server-side already removed from the open list, and
             // in that case we can directly respond to the client with a ContainerClosePacket
@@ -27,7 +45,12 @@ public class ContainerClosePacketProcessor extends PacketProcessor<ContainerClos
             return;
         }
 
-        ((AllayPlayer) player).setContainerClosedByClient(true);
+        var allayPlayer = (AllayPlayer) player;
+        if (suppressCloseResponse) {
+            allayPlayer.setSuppressNextContainerClosePacket(true);
+        } else {
+            allayPlayer.setContainerClosedByClient(true);
+        }
         opened.removeViewer(player);
     }
 

--- a/server/src/main/java/org/allaymc/server/player/AllayPlayer.java
+++ b/server/src/main/java/org/allaymc/server/player/AllayPlayer.java
@@ -181,6 +181,8 @@ public class AllayPlayer implements Player {
     @Getter
     @Setter
     protected boolean containerClosedByClient;
+    @Setter
+    protected boolean suppressNextContainerClosePacket;
     @Getter
     protected Speed speed, flySpeed, verticalFlySpeed;
     @Getter
@@ -2173,6 +2175,12 @@ public class AllayPlayer implements Player {
 
     @SneakyThrows
     protected void sendContainerClosePacket(byte assignedId, Container container) {
+        if (this.suppressNextContainerClosePacket) {
+            this.suppressNextContainerClosePacket = false;
+            this.containerClosedByClient = false;
+            return;
+        }
+
         var packet = new ContainerClosePacket();
         packet.setId(assignedId);
         packet.setType(ContainerNetworkInfo.getInfo(container.getContainerType()).toNetworkType());


### PR DESCRIPTION
container state desync frequently happens when, for example, pressing E and ESC in same time, causing inventory to open first, then get interrupted by escape menu, and special `-1` close event were sent by the client. current duplicate viewer handling in form of viewer readding caused even more issues due to container id mismatches on client, resulting in packet violation warnings. 
tested and resolved all issues related to this in all containers, following nukkit approach,