### PR TITLE
feat: more intuitive config saving

### DIFF
--- a/server/src/main/java/org/allaymc/server/AllayServer.java
+++ b/server/src/main/java/org/allaymc/server/AllayServer.java
@@ -248,8 +248,7 @@ public final class AllayServer implements Server {
         // Disable all plugins
         this.pluginManager.disablePlugins();
 
-        // Save all configurations & data
-        SETTINGS.save();
+        // Save all data
         this.scoreboardManager.save();
         this.playerManager.shutdown();
 

--- a/server/src/main/java/org/allaymc/server/command/defaults/SetMaxPlayersCommand.java
+++ b/server/src/main/java/org/allaymc/server/command/defaults/SetMaxPlayersCommand.java
@@ -22,6 +22,7 @@ public class SetMaxPlayersCommand extends Command {
             var maxPlayers = Math.max(Server.getInstance().getPlayerManager().getPlayerCount(), context.getResult(0));
 
             AllayServer.getSettings().genericSettings().maxPlayerCount(maxPlayers);
+            AllayServer.getSettings().save();
             Server.getInstance().getPlayerManager().setMaxPlayerCount(maxPlayers);
             context.addOutput(TrKeys.MC_COMMANDS_SETMAXPLAYERS_SUCCESS, maxPlayers);
             return context.success();

--- a/server/src/main/java/org/allaymc/server/command/defaults/WorldCommand.java
+++ b/server/src/main/java/org/allaymc/server/command/defaults/WorldCommand.java
@@ -14,6 +14,7 @@ import org.allaymc.api.utils.TextFormat;
 import org.allaymc.api.utils.identifier.IdentifierUtils;
 import org.allaymc.api.world.dimension.DimensionTypes;
 import org.allaymc.api.world.generator.WorldGenerator;
+import org.allaymc.server.world.AllayWorldPool;
 
 import java.util.ArrayList;
 import java.util.stream.Collectors;
@@ -150,7 +151,12 @@ public class WorldCommand extends Command {
                                             .apply(response.get(12));
                                 }
 
-                                Server.getInstance().getWorldPool().loadWorld(name, storage, overworldGenerator, netherGenerator, theEndGenerator);
+                                var worldPool = Server.getInstance().getWorldPool();
+                                worldPool.loadWorld(name, storage, overworldGenerator, netherGenerator, theEndGenerator);
+                                var world = worldPool.getWorld(name);
+                                if (world != null) {
+                                    ((AllayWorldPool) worldPool).saveWorldConfig(world);
+                                }
                             })
                             .sendTo(player.getController());
                     return context.success();

--- a/server/src/main/java/org/allaymc/server/player/AllayPlayerManager.java
+++ b/server/src/main/java/org/allaymc/server/player/AllayPlayerManager.java
@@ -66,9 +66,6 @@ public class AllayPlayerManager implements PlayerManager {
 
     public void shutdown() {
         this.playerStorage.shutdown();
-        this.banInfo.save();
-        this.whitelist.save();
-        this.operators.save();
     }
 
     @Override
@@ -112,6 +109,7 @@ public class AllayPlayerManager implements PlayerManager {
         }
 
         banInfo.bannedPlayers().add(uuidOrName);
+        banInfo.save();
         players.values().stream()
                 .filter(player -> player.getLoginData().getUuid().toString().equals(uuidOrName) || player.getOriginName().equals(uuidOrName))
                 .forEach(player -> player.disconnect("You are banned!"));
@@ -131,6 +129,7 @@ public class AllayPlayerManager implements PlayerManager {
         }
 
         banInfo.bannedPlayers().remove(uuidOrName);
+        banInfo.save();
         return true;
     }
 
@@ -156,6 +155,7 @@ public class AllayPlayerManager implements PlayerManager {
         }
 
         banInfo.bannedIps().add(ip);
+        banInfo.save();
         players.values().stream()
                 .filter(player -> AllayStringUtils.fastTwoPartSplit(player.getSocketAddress().toString().substring(1), ":", "")[0].equals(ip))
                 .forEach(player -> player.disconnect(TrKeys.ALLAY_DISCONNECT_BANIP));
@@ -175,6 +175,7 @@ public class AllayPlayerManager implements PlayerManager {
         }
 
         banInfo.bannedIps().remove(ip);
+        banInfo.save();
         return true;
     }
 
@@ -196,6 +197,7 @@ public class AllayPlayerManager implements PlayerManager {
         }
 
         AllayServer.getSettings().genericSettings().enableWhitelist(enable);
+        AllayServer.getSettings().save();
         if (enable) {
             getPlayers().values().stream()
                     .filter(player -> !isWhitelisted(player))
@@ -219,7 +221,11 @@ public class AllayPlayerManager implements PlayerManager {
             return false;
         }
 
-        return whitelist.whitelist().add(uuidOrName);
+        var added = whitelist.whitelist().add(uuidOrName);
+        if (added) {
+            whitelist.save();
+        }
+        return added;
     }
 
     @Override
@@ -234,6 +240,7 @@ public class AllayPlayerManager implements PlayerManager {
         }
 
         whitelist.whitelist().remove(uuidOrName);
+        whitelist.save();
         players.values().stream()
                 .filter(player -> player.getLoginData().getUuid().toString().equals(uuidOrName) || player.getOriginName().equals(uuidOrName))
                 .forEach(player -> player.disconnect(TrKeys.MC_DISCONNECTIONSCREEN_NOTALLOWED));
@@ -261,6 +268,7 @@ public class AllayPlayerManager implements PlayerManager {
         } else {
             operators.operators().remove(uuidOrName);
         }
+        operators.save();
 
         players.values().stream()
                 .filter(p -> p.getLoginData().getUuid().toString().equals(uuidOrName) || p.getOriginName().equals(uuidOrName))

--- a/server/src/main/java/org/allaymc/server/world/AllayWorldPool.java
+++ b/server/src/main/java/org/allaymc/server/world/AllayWorldPool.java
@@ -81,16 +81,6 @@ public final class AllayWorldPool implements WorldPool {
         while (this.worlds.values().stream().anyMatch(world -> world.getState() != WorldState.STOPPED)) {
             Thread.onSpinWait();
         }
-
-        // Save world settings
-        this.worldConfig.worlds().clear();
-        this.worlds.forEach((name, world) -> {
-            if (!world.isRuntimeOnly()) {
-                this.worldConfig.worlds().put(name, toWorldSetting(world));
-            }
-        });
-        applyBuiltinDimensionSettings(BuiltinDimensionSettings.get());
-        this.worldConfig.save();
     }
 
     @Override
@@ -167,6 +157,17 @@ public final class AllayWorldPool implements WorldPool {
 
         world.shutdown();
         this.worlds.remove(name);
+        this.worldConfig.worlds().remove(name);
+        this.worldConfig.save();
+    }
+
+    public void saveWorldConfig(World world) {
+        if (world.isRuntimeOnly()) {
+            this.worldConfig.worlds().remove(world.getName());
+        } else {
+            this.worldConfig.worlds().put(world.getName(), toWorldSetting(world));
+        }
+        this.worldConfig.save();
     }
 
     @Override


### PR DESCRIPTION
kinda opinionated, but currently editing the config on a live server and then restarting causes the server to restore the original config. that feels unintuitive, requires the server to be shut down earlier than actually necessary, and I don't remember this being the case in any other server software.
my change only overwrites the config when some state is explicitly changed by an OP or a plugin (like a whitelist update), so conflicts would only have chance to happen if something updated the server settings at the exact same time someone was editing it, instead of forbidding it entirely.
