### PR TITLE
fix: resource pack manifest parsing

### DIFF
--- a/server/src/main/java/org/allaymc/server/pack/PackEncryptor.java
+++ b/server/src/main/java/org/allaymc/server/pack/PackEncryptor.java
@@ -2,11 +2,11 @@ package org.allaymc.server.pack;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonParser;
 import com.google.gson.Strictness;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.allaymc.api.pack.PackManifest;
-import org.allaymc.server.utils.JSONUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 
 import javax.crypto.Cipher;
@@ -215,8 +215,10 @@ public final class PackEncryptor {
             throw new IllegalArgumentException("manifest file not exists");
         }
 
-        var manifest = JSONUtils.from(new InputStreamReader(zip.getInputStream(manifestEntry), StandardCharsets.UTF_8), PackManifest.class);
-        return manifest.getHeader().getUuid().toString();
+        try (var reader = new InputStreamReader(zip.getInputStream(manifestEntry), StandardCharsets.UTF_8)) {
+            var manifest = JsonParser.parseReader(reader).getAsJsonObject();
+            return manifest.getAsJsonObject("header").get("uuid").getAsString();
+        }
     }
 
     @SneakyThrows


### PR DESCRIPTION
fully parsing PackManifest for uuid loading seems to cause some problems.

perfectly legal manifest:
```
{
    "format_version": 2,
    "header": {
        "name": "...",
        "description": "...",
        "uuid": "ab32509b-f3c2-4406-b3c3-b99379100328",
        "version": [1, 0, 0],
        "min_engine_version": [1, 21, 50 ]
    },
    "modules": [
        {
            "description": "...",
            "type": "resources",
            "uuid": "79396c6e-b108-4b29-ba2b-190ff4df2d99",
            "version": [1, 0, 0]
        }
    ]
}
```

wasn't able to be parsed due to some PackVersion incompatibilities:
```
[11:54:02 ERROR] [main] [PackEncryptor] Failed to encrypt pack
  com.google.gson.JsonSyntaxException: java.lang.IllegalStateException: Expected BEGIN_OBJECT but was BEGIN_ARRAY at line 1 column 202 path
  $.header.version
  See https://github.com/google/gson/blob/main/Troubleshooting.md#unexpected-json-structure
          at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:521)
          at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$2.readIntoField(ReflectiveTypeAdapterFactory.java:271)
          at
  com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$FieldReflectionAdapter.readField(ReflectiveTypeAdapterFactory.java:559)
          at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:517)
          at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$2.readIntoField(ReflectiveTypeAdapterFactory.java:271)
          at
  com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$FieldReflectionAdapter.readField(ReflectiveTypeAdapterFactory.java:559)
```

just reading only `uuid` field seems to resolve this and any other possible future issues.