### PR TITLE
player duplicate login handling improvements

### DIFF
--- a/server/src/main/java/org/allaymc/server/network/processor/login/LoginPacketProcessor.java
+++ b/server/src/main/java/org/allaymc/server/network/processor/login/LoginPacketProcessor.java
@@ -73,9 +73,14 @@ public class LoginPacketProcessor extends ILoginPacketProcessor<LoginPacket> {
             return;
         }
 
-        var otherDevice = server.getPlayerManager().getPlayers().get(loginData.getUuid());
-        if (otherDevice != null) {
-            otherDevice.disconnect(TrKeys.MC_DISCONNECTIONSCREEN_LOGGEDINOTHERLOCATION);
+        var otherPlayer = server.getPlayerManager().getPlayers().get(loginData.getUuid());
+        if (otherPlayer != null) {
+            if (otherPlayer.getLoginData().getDeviceInfo().equals(loginData.getDeviceInfo())) {
+                otherPlayer.disconnect(TrKeys.MC_DISCONNECTIONSCREEN_LOGGEDINOTHERLOCATION);
+            } else {
+                player.disconnect(TrKeys.MC_DISCONNECTIONSCREEN_LOGGEDINOTHERLOCATION);
+                return;
+            }
         }
 
         if (!AllayServer.getSettings().networkSettings().enableNetworkEncryption()) {

--- a/server/src/main/java/org/allaymc/server/player/AllayPlayerManager.java
+++ b/server/src/main/java/org/allaymc/server/player/AllayPlayerManager.java
@@ -277,7 +277,12 @@ public class AllayPlayerManager implements PlayerManager {
     }
 
     public synchronized void addPlayer(Player player) {
-        this.players.put(player.getLoginData().getUuid(), player);
+        var previous = this.players.put(player.getLoginData().getUuid(), player);
+        if (previous != null) {
+            // May happen if two players with same uuid try to connect in same time
+            previous.disconnect(TrKeys.MC_DISCONNECTIONSCREEN_BODY_LOGGEDINELSEWHERE);
+        }
+
         updatePlayerCount();
         Server.getInstance().getMessageChannel().addReceiver(player.getControlledEntity());
         broadcastPlayerListChange(player, true);
@@ -291,8 +296,11 @@ public class AllayPlayerManager implements PlayerManager {
 
         // At this time the client has disconnected
         if (player.getLastClientState().ordinal() >= ClientState.SPAWNED.ordinal()) {
-            this.players.remove(player.getLoginData().getUuid());
-            updatePlayerCount();
+            var uuid = player.getLoginData().getUuid();
+            if (this.players.get(uuid) == player) {
+                this.players.remove(uuid);
+                updatePlayerCount();
+            }
 
             var event = new PlayerQuitEvent(player, TextFormat.YELLOW + "%" + TrKeys.MC_MULTIPLAYER_PLAYER_LEFT);
             event.call();


### PR DESCRIPTION
improves concurrent connection handling:
- players are now verified to have the same device before disconnecting a player with a matching uuid. this prevents malicious offline players from kicking other clients by spoofing their uuid.
- AllayPlayerManager.addPlayer and removePlayer now handle duplicate additions correctly. previously, if a player logged in with the same uuid before either client had spawned, the new player would overwrite the existing entry in the player list while the original player remained spawned, which would have led to a serious desync.