### PR TITLE
fix: setPropertyValues() fails to update multiple block properties at once

### DIFF
--- a/server/src/main/java/org/allaymc/server/block/type/AllayBlockState.java
+++ b/server/src/main/java/org/allaymc/server/block/type/AllayBlockState.java
@@ -110,12 +110,17 @@ public record AllayBlockState(
         var succeedCount = 0;
         var succeed = new boolean[propertyValues.size()];
         for (int i = 0; i < blockPropertyValues.length; i++) {
-            int index;
-            if ((index = propertyValues.indexOf(blockPropertyValues[i])) != -1) {
-                succeedCount++;
-                succeed[index] = true;
-                newPropertyValues[i] = propertyValues.get(index);
-            } else newPropertyValues[i] = blockPropertyValues[i];
+            var found = false;
+            for (int j = 0; j < propertyValues.size(); j++) {
+                if (propertyValues.get(j).getPropertyType() == blockPropertyValues[i].getPropertyType()) {
+                    succeedCount++;
+                    succeed[j] = true;
+                    newPropertyValues[i] = propertyValues.get(j);
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) newPropertyValues[i] = blockPropertyValues[i];
         }
 
         if (succeedCount != propertyValues.size()) {


### PR DESCRIPTION
`setPropertyValues()` throws `IllegalArgumentException` whenever you actually
change a property, because it does:

```java
if ((index = propertyValues.indexOf(blockPropertyValues[i])) != -1) {
```

`blockPropertyValues[i]` is the old value, `propertyValues` is the new
values, it's searching for the old value inside the new-value list, which
is backwards, so it basically never matches. Fixed it to match by
`getPropertyType()` instead, same as `setPropertyValue()` already
does a few lines above.