### PR TITLE
Reflector: Improve class naming

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ netty = "4.2.14.Final"
 # NBT
 nbt = { group = "org.allaymc", name = "nbt", version = "3.0.12" }
 # Protocol
-protocol = { group = "org.allaymc.protocol", name = "bedrock-connection", version = "1.26.20-R3" }
+protocol = { group = "org.allaymc.protocol", name = "bedrock-connection", version = "1.26.30-R1" }
 # State Updater
 updater-common = { group = "org.allaymc.stateupdater", name = "common", version = "0.1.1" }
 item-updater = { group = "org.allaymc.stateupdater", name = "item-updater", version = "1.21.110-R1" }

--- a/server/src/main/java/org/allaymc/server/AllayServer.java
+++ b/server/src/main/java/org/allaymc/server/AllayServer.java
@@ -32,7 +32,7 @@ import org.allaymc.server.plugin.AllayPluginManager;
 import org.allaymc.server.scheduler.AllayScheduler;
 import org.allaymc.server.scroreboard.JsonScoreboardStorage;
 import org.allaymc.server.terminal.AllayTerminalConsole;
-import org.allaymc.server.utils.AllayForkJoinWorkerThreadFactory;
+import org.allaymc.server.utils.AllayComputeThreadFactory;
 import org.allaymc.server.utils.GameLoop;
 import org.allaymc.server.utils.SignalUtils;
 import org.allaymc.server.utils.Utils;
@@ -154,7 +154,7 @@ public final class AllayServer implements Server {
                 SETTINGS.genericSettings().maxComputeThreadCount() <= 0 ?
                         Runtime.getRuntime().availableProcessors() :
                         SETTINGS.genericSettings().maxComputeThreadCount(),
-                new AllayForkJoinWorkerThreadFactory(), null, true
+                new AllayComputeThreadFactory(), null, true
         );
     }
 

--- a/server/src/main/java/org/allaymc/server/datastruct/aabb/AABBTree.java
+++ b/server/src/main/java/org/allaymc/server/datastruct/aabb/AABBTree.java
@@ -26,7 +26,7 @@ public final class AABBTree<T extends HasAABB & HasLongId> {
     public static final float DEFAULT_FAT_AABB_MARGIN = 0f;
 
     private final List<AABBTreeNode<T>> nodes;
-    private final AABBTreeHeuristicFunction<T> insertionHeuristicFunction;
+    private final AABBTreeHeuristic<T> insertionHeuristicFunction;
     private final AABBOverlapFilter<T> defaultAABBOverlapFilter;
     private final CollisionFilter<T> defaultCollisionFilter;
     private final Map<AABBTreeObject<T>, Integer> objects;
@@ -38,10 +38,10 @@ public final class AABBTree<T extends HasAABB & HasLongId> {
     private int root;
 
     public AABBTree() {
-        this(new AreaAABBHeuristicFunction<>(), DEFAULT_FAT_AABB_MARGIN);
+        this(new AreaAABBHeuristic<>(), DEFAULT_FAT_AABB_MARGIN);
     }
 
-    public AABBTree(AABBTreeHeuristicFunction<T> insertionHeuristicFunction, float fatAABBMargin) {
+    public AABBTree(AABBTreeHeuristic<T> insertionHeuristicFunction, float fatAABBMargin) {
         nodes = new ObjectArrayList<>();
         root = AABBTreeNode.INVALID_NODE_INDEX;
         this.insertionHeuristicFunction = insertionHeuristicFunction;
@@ -239,9 +239,9 @@ public final class AABBTree<T extends HasAABB & HasLongId> {
             AABBd aabbA = leftChild.getAabb();
             AABBd aabbB = rightChild.getAabb();
 
-            AABBTreeHeuristicFunction.HeuristicResult heuristicResult = insertionHeuristicFunction
+            AABBTreeHeuristic.HeuristicResult heuristicResult = insertionHeuristicFunction
                     .getInsertionHeuristic(aabbA, aabbB, nodeToAdd.getData(), nodeToAddAABB);
-            parentNode = AABBTreeHeuristicFunction.HeuristicResult.LEFT.equals(heuristicResult) ? leftChild : rightChild;
+            parentNode = AABBTreeHeuristic.HeuristicResult.LEFT.equals(heuristicResult) ? leftChild : rightChild;
         }
 
         int oldParentIndex = parentNode.getParent();

--- a/server/src/main/java/org/allaymc/server/datastruct/aabb/AABBTreeHeuristic.java
+++ b/server/src/main/java/org/allaymc/server/datastruct/aabb/AABBTreeHeuristic.java
@@ -7,7 +7,7 @@ import org.joml.primitives.AABBd;
  * @author daoge_cmd
  */
 @FunctionalInterface
-public interface AABBTreeHeuristicFunction<T extends HasAABB> {
+public interface AABBTreeHeuristic<T extends HasAABB> {
     HeuristicResult getInsertionHeuristic(AABBd left, AABBd right, T object, AABBd objectAABB);
 
     enum HeuristicResult {

--- a/server/src/main/java/org/allaymc/server/datastruct/aabb/AreaAABBHeuristic.java
+++ b/server/src/main/java/org/allaymc/server/datastruct/aabb/AreaAABBHeuristic.java
@@ -8,7 +8,7 @@ import static org.allaymc.server.datastruct.aabb.AABBUtils.getArea;
 /**
  * @author daoge_cmd
  */
-public class AreaAABBHeuristicFunction<T extends HasAABB> implements AABBTreeHeuristicFunction<T> {
+public class AreaAABBHeuristic<T extends HasAABB> implements AABBTreeHeuristic<T> {
     private final AABBd temp = new AABBd();
 
     @Override

--- a/server/src/main/java/org/allaymc/server/network/ProtocolInfo.java
+++ b/server/src/main/java/org/allaymc/server/network/ProtocolInfo.java
@@ -7,6 +7,7 @@ import org.allaymc.updater.block.BlockStateUpdater_1_21_110;
 import org.allaymc.updater.item.ItemStateUpdater;
 import org.allaymc.updater.item.ItemStateUpdater_1_21_110;
 import org.cloudburstmc.protocol.bedrock.codec.BedrockCodec;
+import org.cloudburstmc.protocol.bedrock.codec.v1001.Bedrock_v1001;
 import org.cloudburstmc.protocol.bedrock.codec.v818.Bedrock_v818;
 import org.cloudburstmc.protocol.bedrock.codec.v819.Bedrock_v819;
 import org.cloudburstmc.protocol.bedrock.codec.v827.Bedrock_v827;
@@ -33,6 +34,7 @@ public final class ProtocolInfo {
      */
     public static final List<BedrockCodec> SUPPORTED_VERSIONS = List.of(
             // Order is important. The first codec is the latest supported version.
+            Bedrock_v1001.CODEC,
             Bedrock_v975.CODEC,
             Bedrock_v944.CODEC,
             Bedrock_v924.CODEC,

--- a/server/src/main/java/org/allaymc/server/player/AllayLoginData.java
+++ b/server/src/main/java/org/allaymc/server/player/AllayLoginData.java
@@ -126,6 +126,10 @@ public class AllayLoginData implements LoginData {
             this.deviceInfo = new DeviceInfo(deviceModel, deviceId, clientId, Device.from(deviceOS), UIProfile.from(uiProfile));
         }
 
+        if (!this.authed && this.xname.isEmpty() && skinMap.has("ThirdPartyName")) {
+            this.xname = skinMap.get("ThirdPartyName").getAsString();
+        }
+
         if (skinMap.has("LanguageCode")) {
             this.langCode = LangCode.valueOf(skinMap.get("LanguageCode").getAsString());
         }

--- a/server/src/main/java/org/allaymc/server/utils/AllayComputeThreadFactory.java
+++ b/server/src/main/java/org/allaymc/server/utils/AllayComputeThreadFactory.java
@@ -8,7 +8,7 @@ import java.util.concurrent.ForkJoinWorkerThread;
 /**
  * @author daoge_cmd
  */
-public class AllayForkJoinWorkerThreadFactory implements ForkJoinPool.ForkJoinWorkerThreadFactory {
+public class AllayComputeThreadFactory implements ForkJoinPool.ForkJoinWorkerThreadFactory {
     @Override
     public ForkJoinWorkerThread newThread(ForkJoinPool pool) {
         var thread = ForkJoinPool.defaultForkJoinWorkerThreadFactory.newThread(pool);


### PR DESCRIPTION
## Summary
- This PR renames a few classes to make their names shorter and more descriptive.
## Changes
- Rename `AllayForkJoinWorkerThreadFactory` to `AllayComputeThreadFactory`.
- Rename `AABBTreeHeuristicFunctio`n to `AABBTreeHeuristic`.
- Rename `AreaAABBHeuristicFunction` to `AreaAABBHeuristic`.