### PR TITLE
feat: implement bubble columns

### DIFF
--- a/api/src/main/java/org/allaymc/api/entity/component/EntityBaseComponent.java
+++ b/api/src/main/java/org/allaymc/api/entity/component/EntityBaseComponent.java
@@ -2,6 +2,8 @@ package org.allaymc.api.entity.component;
 
 import org.allaymc.api.block.data.BlockFace;
 import org.allaymc.api.block.data.BlockTags;
+import org.allaymc.api.block.type.BlockState;
+import org.allaymc.api.block.type.BlockTypes;
 import org.allaymc.api.block.dto.Block;
 import org.allaymc.api.command.CommandSender;
 import org.allaymc.api.primitiveshape.PrimitiveShape;
@@ -736,7 +738,7 @@ public interface EntityBaseComponent extends EntityComponent, CommandSender, Has
         var eyeLoc = getLocation().add(0, getEyeHeight(), 0, new Vector3d());
         var eyesBlockState = dim.getBlockState(eyeLoc);
 
-        return eyesBlockState.getBlockType().hasBlockTag(BlockTags.WATER) &&
+        return isWaterOrBubbleColumn(eyesBlockState) &&
                eyesBlockState.getBlockStateData().computeOffsetShape(MathUtils.floor(eyeLoc)).intersectsPoint(eyeLoc);
     }
 
@@ -750,8 +752,13 @@ public interface EntityBaseComponent extends EntityComponent, CommandSender, Has
         var loc = getLocation();
         var blockState = dim.getBlockState(loc);
 
-        return blockState.getBlockType().hasBlockTag(BlockTags.WATER) &&
+        return isWaterOrBubbleColumn(blockState) &&
                blockState.getBlockStateData().computeOffsetShape(MathUtils.floor(loc)).intersectsPoint(loc);
+    }
+
+    private static boolean isWaterOrBubbleColumn(BlockState blockState) {
+        return blockState.getBlockType().hasBlockTag(BlockTags.WATER) ||
+               blockState.getBlockType() == BlockTypes.BUBBLE_COLUMN;
     }
 
     /**

--- a/server/src/main/java/org/allaymc/server/block/component/BlockBubbleColumnBaseComponentImpl.java
+++ b/server/src/main/java/org/allaymc/server/block/component/BlockBubbleColumnBaseComponentImpl.java
@@ -1,0 +1,143 @@
+package org.allaymc.server.block.component;
+
+import org.allaymc.api.block.BlockBehavior;
+import org.allaymc.api.block.component.BlockLiquidBaseComponent;
+import org.allaymc.api.block.data.BlockFace;
+import org.allaymc.api.block.data.BlockTags;
+import org.allaymc.api.block.dto.Block;
+import org.allaymc.api.block.dto.PlayerInteractInfo;
+import org.allaymc.api.block.property.type.BlockPropertyTypes;
+import org.allaymc.api.block.type.BlockState;
+import org.allaymc.api.block.type.BlockType;
+import org.allaymc.api.block.type.BlockTypes;
+import org.allaymc.api.world.Dimension;
+import org.joml.Vector3i;
+import org.joml.Vector3ic;
+
+/**
+ * Allay Project 2026/7/12
+ *
+ * @author Miroshka000
+ */
+public class BlockBubbleColumnBaseComponentImpl extends BlockBaseComponentImpl {
+    public BlockBubbleColumnBaseComponentImpl(BlockType<? extends BlockBehavior> blockType) {
+        super(blockType);
+    }
+
+    @Override
+    public void afterPlaced(Block oldBlock, BlockState newBlockState, PlayerInteractInfo placementInfo) {
+        super.afterPlaced(oldBlock, newBlockState, placementInfo);
+        updateAt(oldBlock.getDimension(), oldBlock.getPosition());
+    }
+
+    @Override
+    public void onNeighborUpdate(Block block, Block neighbor, BlockFace face, BlockState oldNeighborState) {
+        super.onNeighborUpdate(block, neighbor, face, oldNeighborState);
+        updateAt(block.getDimension(), block.getPosition());
+    }
+
+    @Override
+    public void afterNeighborLayerReplace(Block currentBlock, BlockState newBlockState, PlayerInteractInfo placementInfo) {
+        super.afterNeighborLayerReplace(currentBlock, newBlockState, placementInfo);
+        updateAt(currentBlock.getDimension(), currentBlock.getPosition());
+    }
+
+    public static void updateAbove(Block block) {
+        updateAt(block.getDimension(), BlockFace.UP.offsetPos(block.getPosition()));
+    }
+
+    public static void updateAt(Dimension dimension, Vector3ic position) {
+        var cursor = new Vector3i(position);
+        var direction = getDirection(dimension, BlockFace.DOWN.offsetPos(cursor));
+
+        while (dimension.isYInRange(cursor.y())) {
+            var current = dimension.getBlockState(cursor);
+            if (direction == null) {
+                if (current.getBlockType() != BlockTypes.BUBBLE_COLUMN || !restoreWater(dimension, cursor)) {
+                    return;
+                }
+
+                cursor.add(0, 1, 0);
+                continue;
+            }
+
+            if (current.getBlockType() == BlockTypes.BUBBLE_COLUMN) {
+                if (!isSourceWater(dimension.getBlockState(cursor, 1))) {
+                    if (!restoreWater(dimension, cursor)) {
+                        return;
+                    }
+                    direction = null;
+                    cursor.add(0, 1, 0);
+                    continue;
+                }
+
+                if (current.getPropertyValue(BlockPropertyTypes.DRAG_DOWN) != direction.booleanValue() &&
+                    !setBubbleColumnDirection(dimension, cursor, current, direction)) {
+                    return;
+                }
+
+                cursor.add(0, 1, 0);
+                continue;
+            }
+
+            if (!isSourceWater(current) || !replaceWithBubbleColumn(dimension, cursor, current, direction)) {
+                return;
+            }
+            cursor.add(0, 1, 0);
+        }
+    }
+
+    private static Boolean getDirection(Dimension dimension, Vector3ic position) {
+        var below = dimension.getBlockState(position);
+        if (below.getBlockType() == BlockTypes.BUBBLE_COLUMN) {
+            return below.getPropertyValue(BlockPropertyTypes.DRAG_DOWN);
+        }
+        if (below.getBlockType() == BlockTypes.MAGMA) {
+            return true;
+        }
+        if (below.getBlockType() == BlockTypes.SOUL_SAND) {
+            return false;
+        }
+        return null;
+    }
+
+    private static boolean isSourceWater(BlockState state) {
+        return state.getBlockType().hasBlockTag(BlockTags.WATER) &&
+               state.getBehavior() instanceof BlockLiquidBaseComponent &&
+               BlockLiquidBaseComponent.isSource(state);
+    }
+
+    private static boolean setBubbleColumnDirection(
+            Dimension dimension, Vector3ic position, BlockState current, boolean dragDown
+    ) {
+        var updated = current.setPropertyValue(BlockPropertyTypes.DRAG_DOWN, dragDown);
+        return dimension.setBlockState(position, updated, 0, true, true, false);
+    }
+
+    private static boolean replaceWithBubbleColumn(
+            Dimension dimension, Vector3ic position, BlockState water, boolean dragDown
+    ) {
+        var bubbleColumn = BlockTypes.BUBBLE_COLUMN.ofState(BlockPropertyTypes.DRAG_DOWN.createValue(dragDown));
+        if (!dimension.setBlockState(position, water, 1, true, false, false)) {
+            return false;
+        }
+        if (dimension.setBlockState(position, bubbleColumn, 0, true, true, false)) {
+            return true;
+        }
+
+        dimension.setBlockState(position, BlockTypes.AIR.getDefaultState(), 1, true, false, false);
+        return false;
+    }
+
+    private static boolean restoreWater(Dimension dimension, Vector3ic position) {
+        var water = dimension.getBlockState(position, 1);
+        if (!isSourceWater(water)) {
+            water = BlockTypes.WATER.getDefaultState();
+        }
+
+        if (!dimension.setBlockState(position, water, 0, true, true, false)) {
+            return false;
+        }
+        return dimension.setBlockState(position, BlockTypes.AIR.getDefaultState(), 1, true, false, false);
+    }
+}

--- a/server/src/main/java/org/allaymc/server/block/component/BlockSoulSandBaseComponentImpl.java
+++ b/server/src/main/java/org/allaymc/server/block/component/BlockSoulSandBaseComponentImpl.java
@@ -6,16 +6,14 @@ import org.allaymc.api.block.dto.Block;
 import org.allaymc.api.block.dto.PlayerInteractInfo;
 import org.allaymc.api.block.type.BlockState;
 import org.allaymc.api.block.type.BlockType;
-import org.allaymc.api.entity.Entity;
-import org.allaymc.api.entity.damage.DamageContainer;
-import org.allaymc.api.entity.interfaces.EntityLiving;
-import org.allaymc.api.entity.interfaces.EntityPlayer;
 
 /**
- * @author IWareQ
+ * Allay Project 2026/7/12
+ *
+ * @author Miroshka000
  */
-public class BlockMagmaBaseComponentImpl extends BlockBaseComponentImpl {
-    public BlockMagmaBaseComponentImpl(BlockType<? extends BlockBehavior> blockType) {
+public class BlockSoulSandBaseComponentImpl extends BlockBaseComponentImpl {
+    public BlockSoulSandBaseComponentImpl(BlockType<? extends BlockBehavior> blockType) {
         super(blockType);
     }
 
@@ -30,17 +28,6 @@ public class BlockMagmaBaseComponentImpl extends BlockBaseComponentImpl {
         super.onNeighborUpdate(block, neighbor, face, oldNeighborState);
         if (face == BlockFace.UP) {
             BlockBubbleColumnBaseComponentImpl.updateAbove(block);
-        }
-    }
-
-    @Override
-    public void onCollideWithEntity(Block block, Entity entity) {
-        if (entity instanceof EntityLiving living) {
-            if (entity instanceof EntityPlayer player && player.isSneaking()) {
-                return;
-            }
-
-            living.attack(DamageContainer.magma(1));
         }
     }
 }

--- a/server/src/main/java/org/allaymc/server/block/type/BlockTypeInitializer.java
+++ b/server/src/main/java/org/allaymc/server/block/type/BlockTypeInitializer.java
@@ -1139,6 +1139,15 @@ public final class BlockTypeInitializer {
                 .build();
     }
 
+    public static void initBubbleColumn() {
+        BlockTypes.BUBBLE_COLUMN = AllayBlockType
+                .builder(BlockBubbleColumnBehaviorImpl.class)
+                .vanillaBlock(BlockId.BUBBLE_COLUMN)
+                .setProperties(BlockPropertyTypes.DRAG_DOWN)
+                .setBaseComponentSupplier(BlockBubbleColumnBaseComponentImpl::new)
+                .build();
+    }
+
     public static void initLava() {
         BlockTypes.LAVA = AllayBlockType
                 .builder(BlockLiquidBehaviorImpl.class)
@@ -1694,6 +1703,14 @@ public final class BlockTypeInitializer {
                 .builder(BlockMagmaBehaviorImpl.class)
                 .vanillaBlock(BlockId.MAGMA)
                 .setBaseComponentSupplier(BlockMagmaBaseComponentImpl::new)
+                .build();
+    }
+
+    public static void initSoulSand() {
+        BlockTypes.SOUL_SAND = AllayBlockType
+                .builder(BlockSoulSandBehaviorImpl.class)
+                .vanillaBlock(BlockId.SOUL_SAND)
+                .setBaseComponentSupplier(BlockSoulSandBaseComponentImpl::new)
                 .build();
     }
 

--- a/server/src/main/java/org/allaymc/server/world/physics/AllayEntityPhysicsEngine.java
+++ b/server/src/main/java/org/allaymc/server/world/physics/AllayEntityPhysicsEngine.java
@@ -5,6 +5,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.allaymc.api.block.component.BlockLiquidBaseComponent;
 import org.allaymc.api.block.data.BlockFace;
 import org.allaymc.api.block.data.BlockTags;
+import org.allaymc.api.block.property.type.BlockPropertyTypes;
+import org.allaymc.api.block.type.BlockTypes;
 import org.allaymc.api.block.type.BlockState;
 import org.allaymc.api.entity.Entity;
 import org.allaymc.api.entity.component.EntityPhysicsComponent;
@@ -68,6 +70,14 @@ public class AllayEntityPhysicsEngine implements EntityPhysicsEngine {
     private static final double WATER_FLOW_MOTION = 0.014;
     private static final double LAVA_FLOW_MOTION = 0.002333333;
     private static final double LAVA_FLOW_MOTION_IN_NETHER = 0.007;
+    private static final double BUBBLE_COLUMN_UPWARD_ACCELERATION = 0.06;
+    private static final double BUBBLE_COLUMN_UPWARD_EXIT_ACCELERATION = 0.10;
+    private static final double BUBBLE_COLUMN_DOWNWARD_ACCELERATION = 0.30;
+    private static final double BUBBLE_COLUMN_DOWNWARD_EXIT_ACCELERATION = 0.03;
+    private static final double BUBBLE_COLUMN_UPWARD_MAX_SPEED = 0.70;
+    private static final double BUBBLE_COLUMN_UPWARD_EXIT_MAX_SPEED = 1.80;
+    private static final double BUBBLE_COLUMN_DOWNWARD_MAX_SPEED = -0.30;
+    private static final double BUBBLE_COLUMN_DOWNWARD_EXIT_MAX_SPEED = -0.90;
 
     static {
         var settings = AllayServer.getSettings().entitySettings().physicsEngineSettings();
@@ -283,9 +293,26 @@ public class AllayEntityPhysicsEngine implements EntityPhysicsEngine {
         var inLava = new AtomicBoolean(false);
         var waterMotion = new Vector3d();
         var lavaMotion = new Vector3d();
+        var upwardBubbleColumn = new AtomicBoolean(false);
+        var downwardBubbleColumn = new AtomicBoolean(false);
+        var bubbleColumnExit = new AtomicBoolean(false);
         var entityY = entity.getLocation().y();
 
         dimension.forEachBlockStates(entity.getOffsetAABB(), 0, (x, y, z, block) -> {
+            if (block.getBlockType() == BlockTypes.BUBBLE_COLUMN) {
+                inWater.set(true);
+                ((EntityPhysicsComponent) entity).resetFallDistance();
+                if (block.getPropertyValue(BlockPropertyTypes.DRAG_DOWN)) {
+                    downwardBubbleColumn.set(true);
+                } else {
+                    upwardBubbleColumn.set(true);
+                }
+                if (dimension.getBlockState(x, y + 1, z).getBlockType() == AIR) {
+                    bubbleColumnExit.set(true);
+                }
+                return;
+            }
+
             if (!(block.getBehavior() instanceof BlockLiquidBehaviorImpl liquidBehavior)) {
                 return;
             }
@@ -331,7 +358,25 @@ public class AllayEntityPhysicsEngine implements EntityPhysicsEngine {
             ((EntityPhysicsComponent) entity).addMotion(finalMotion);
         }
 
+        applyBubbleColumnMotion(entity, upwardBubbleColumn.get(), downwardBubbleColumn.get(), bubbleColumnExit.get());
+
         return new LiquidState(inWater.get(), inLava.get());
+    }
+
+    private void applyBubbleColumnMotion(Entity entity, boolean upward, boolean downward, boolean exitsColumn) {
+        if (upward == downward) {
+            return;
+        }
+
+        var physics = (EntityPhysicsComponent) entity;
+        var currentMotion = physics.getMotion();
+        var currentY = currentMotion.y();
+        var targetY = upward
+                ? Math.min(exitsColumn ? BUBBLE_COLUMN_UPWARD_EXIT_MAX_SPEED : BUBBLE_COLUMN_UPWARD_MAX_SPEED,
+                currentY + (exitsColumn ? BUBBLE_COLUMN_UPWARD_EXIT_ACCELERATION : BUBBLE_COLUMN_UPWARD_ACCELERATION))
+                : Math.max(exitsColumn ? BUBBLE_COLUMN_DOWNWARD_EXIT_MAX_SPEED : BUBBLE_COLUMN_DOWNWARD_MAX_SPEED,
+                currentY - (exitsColumn ? BUBBLE_COLUMN_DOWNWARD_EXIT_ACCELERATION : BUBBLE_COLUMN_DOWNWARD_ACCELERATION));
+        physics.addMotion(0, targetY - currentY, 0);
     }
 
     protected boolean isAboveMotionThreshold(Vector3dc motion) {

--- a/server/src/test/java/org/allaymc/server/block/component/BlockBubbleColumnBaseComponentImplTest.java
+++ b/server/src/test/java/org/allaymc/server/block/component/BlockBubbleColumnBaseComponentImplTest.java
@@ -1,0 +1,133 @@
+package org.allaymc.server.block.component;
+
+import org.allaymc.api.block.property.type.BlockPropertyTypes;
+import org.allaymc.api.block.type.BlockState;
+import org.allaymc.api.block.type.BlockTypes;
+import org.allaymc.api.world.Dimension;
+import org.allaymc.testutils.AllayTestExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.joml.Vector3i;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Allay Project 2026/7/12
+ *
+ * @author Miroshka000
+ */
+@ExtendWith(AllayTestExtension.class)
+class BlockBubbleColumnBaseComponentImplTest {
+    private final Map<Cell, BlockState> blocks = new HashMap<>();
+    private Dimension dimension;
+
+    @BeforeEach
+    void setUp() {
+        dimension = mock(Dimension.class, CALLS_REAL_METHODS);
+        doReturn(true).when(dimension).isYInRange(anyDouble());
+        doAnswer(invocation ->
+                blocks.getOrDefault(
+                        new Cell(invocation.getArgument(1), invocation.getArgument(3)),
+                        BlockTypes.AIR.getDefaultState()
+                )
+        ).when(dimension).getBlockState(anyInt(), anyInt(), anyInt(), anyInt());
+        doAnswer(invocation -> {
+            blocks.put(new Cell(invocation.getArgument(1), invocation.getArgument(4)), invocation.getArgument(3));
+            return true;
+        }).when(dimension).setBlockState(
+                anyInt(), anyInt(), anyInt(), any(BlockState.class), anyInt(),
+                anyBoolean(), anyBoolean(), anyBoolean(), nullable(org.allaymc.api.block.dto.PlayerInteractInfo.class)
+        );
+    }
+
+    @Test
+    void shouldBuildBubbleColumnThroughAllSourceWaterBlocks() {
+        setMainBlock(0, BlockTypes.SOUL_SAND.getDefaultState());
+        setMainBlock(1, BlockTypes.WATER.getDefaultState());
+        setMainBlock(2, BlockTypes.WATER.getDefaultState());
+        setMainBlock(3, BlockTypes.WATER.getDefaultState());
+        setMainBlock(4, BlockTypes.STONE.getDefaultState());
+
+        BlockBubbleColumnBaseComponentImpl.updateAt(dimension, new Vector3i(0, 1, 0));
+
+        for (int y = 1; y <= 3; y++) {
+            var bubbleColumn = getBlock(y, 0);
+            assertEquals(BlockTypes.BUBBLE_COLUMN, bubbleColumn.getBlockType());
+            assertEquals(false, bubbleColumn.getPropertyValue(BlockPropertyTypes.DRAG_DOWN));
+            assertTrue(org.allaymc.api.block.component.BlockLiquidBaseComponent.isSource(getBlock(y, 1)));
+        }
+        assertEquals(BlockTypes.STONE, getBlock(4, 0).getBlockType());
+    }
+
+    @Test
+    void shouldUpdateDirectionForTheWholeExistingColumn() {
+        setMainBlock(0, BlockTypes.SOUL_SAND.getDefaultState());
+        setMainBlock(1, BlockTypes.WATER.getDefaultState());
+        setMainBlock(2, BlockTypes.WATER.getDefaultState());
+        setMainBlock(3, BlockTypes.STONE.getDefaultState());
+        BlockBubbleColumnBaseComponentImpl.updateAt(dimension, new Vector3i(0, 1, 0));
+
+        setMainBlock(0, BlockTypes.MAGMA.getDefaultState());
+        BlockBubbleColumnBaseComponentImpl.updateAt(dimension, new Vector3i(0, 1, 0));
+
+        for (int y = 1; y <= 2; y++) {
+            assertEquals(true, getBlock(y, 0).getPropertyValue(BlockPropertyTypes.DRAG_DOWN));
+        }
+    }
+
+    @Test
+    void shouldRestoreWaterWhenGeneratorIsRemoved() {
+        setMainBlock(0, BlockTypes.SOUL_SAND.getDefaultState());
+        setMainBlock(1, BlockTypes.WATER.getDefaultState());
+        setMainBlock(2, BlockTypes.WATER.getDefaultState());
+        setMainBlock(3, BlockTypes.STONE.getDefaultState());
+        BlockBubbleColumnBaseComponentImpl.updateAt(dimension, new Vector3i(0, 1, 0));
+
+        setMainBlock(0, BlockTypes.STONE.getDefaultState());
+        BlockBubbleColumnBaseComponentImpl.updateAt(dimension, new Vector3i(0, 1, 0));
+
+        for (int y = 1; y <= 2; y++) {
+            assertEquals(BlockTypes.WATER, getBlock(y, 0).getBlockType());
+            assertTrue(org.allaymc.api.block.component.BlockLiquidBaseComponent.isSource(getBlock(y, 0)));
+            assertEquals(BlockTypes.AIR, getBlock(y, 1).getBlockType());
+        }
+    }
+
+    @Test
+    void shouldStopAtFlowingWater() {
+        setMainBlock(0, BlockTypes.SOUL_SAND.getDefaultState());
+        setMainBlock(1, BlockTypes.WATER.getDefaultState());
+        setMainBlock(2, BlockTypes.FLOWING_WATER.getDefaultState()
+                .setPropertyValue(BlockPropertyTypes.LIQUID_DEPTH, 1));
+
+        BlockBubbleColumnBaseComponentImpl.updateAt(dimension, new Vector3i(0, 1, 0));
+
+        assertEquals(BlockTypes.BUBBLE_COLUMN, getBlock(1, 0).getBlockType());
+        assertEquals(BlockTypes.FLOWING_WATER, getBlock(2, 0).getBlockType());
+    }
+
+    private void setMainBlock(int y, BlockState state) {
+        blocks.put(new Cell(y, 0), state);
+    }
+
+    private BlockState getBlock(int y, int layer) {
+        return blocks.getOrDefault(new Cell(y, layer), BlockTypes.AIR.getDefaultState());
+    }
+
+    private record Cell(int y, int layer) {
+    }
+}


### PR DESCRIPTION
## Summary
- Implements bubble columns produced by soul sand and magma blocks.
- Adds upward/downward entity movement and column propagation/removal.
- Includes focused coverage for the new behavior.

## Testing
- `./gradlew :server:test`
- Manually verified in a Minecraft client.

Related to https://github.com/AllayMC/Allay/issues/867 (item 6)