### PR TITLE
feat: implement goat horn usage

### DIFF
--- a/api/src/main/java/org/allaymc/api/item/data/GoatHornInstrument.java
+++ b/api/src/main/java/org/allaymc/api/item/data/GoatHornInstrument.java
@@ -1,0 +1,44 @@
+package org.allaymc.api.item.data;
+
+import lombok.Getter;
+import org.allaymc.api.message.MayContainTrKey;
+import org.allaymc.api.message.TrKeys;
+import org.allaymc.api.world.sound.SoundNames;
+
+/**
+ * Allay Project 2026/7/12
+ *
+ * @author Miroshka000
+ */
+@Getter
+public enum GoatHornInstrument {
+    PONDER(TrKeys.MC_ITEM_MINECRAFT_GOAT_HORN_SOUND_0, SoundNames.HORN_CALL_0, false),
+    SING(TrKeys.MC_ITEM_MINECRAFT_GOAT_HORN_SOUND_1, SoundNames.HORN_CALL_1, false),
+    SEEK(TrKeys.MC_ITEM_MINECRAFT_GOAT_HORN_SOUND_2, SoundNames.HORN_CALL_2, false),
+    FEEL(TrKeys.MC_ITEM_MINECRAFT_GOAT_HORN_SOUND_3, SoundNames.HORN_CALL_3, false),
+    ADMIRE(TrKeys.MC_ITEM_MINECRAFT_GOAT_HORN_SOUND_4, SoundNames.HORN_CALL_4, true),
+    CALL(TrKeys.MC_ITEM_MINECRAFT_GOAT_HORN_SOUND_5, SoundNames.HORN_CALL_5, true),
+    YEARN(TrKeys.MC_ITEM_MINECRAFT_GOAT_HORN_SOUND_6, SoundNames.HORN_CALL_6, true),
+    DREAM(TrKeys.MC_ITEM_MINECRAFT_GOAT_HORN_SOUND_7, SoundNames.HORN_CALL_7, true);
+
+    private static final GoatHornInstrument[] VALUES = values();
+
+    @MayContainTrKey
+    private final String translationKey;
+    private final String soundName;
+    private final boolean screamingGoatVariant;
+
+    GoatHornInstrument(String translationKey, String soundName, boolean screamingGoatVariant) {
+        this.translationKey = translationKey;
+        this.soundName = soundName;
+        this.screamingGoatVariant = screamingGoatVariant;
+    }
+
+    public int getMeta() {
+        return ordinal();
+    }
+
+    public static GoatHornInstrument fromMeta(int meta) {
+        return meta >= 0 && meta < VALUES.length ? VALUES[meta] : PONDER;
+    }
+}

--- a/api/src/main/java/org/allaymc/api/item/interfaces/ItemGoatHornStack.java
+++ b/api/src/main/java/org/allaymc/api/item/interfaces/ItemGoatHornStack.java
@@ -1,6 +1,16 @@
 package org.allaymc.api.item.interfaces;
 
 import org.allaymc.api.item.ItemStack;
+import org.allaymc.api.item.data.GoatHornInstrument;
+
+import java.util.Objects;
 
 public interface ItemGoatHornStack extends ItemStack {
+    default GoatHornInstrument getInstrument() {
+        return GoatHornInstrument.fromMeta(getMeta());
+    }
+
+    default void setInstrument(GoatHornInstrument instrument) {
+        setMeta(Objects.requireNonNull(instrument, "instrument").getMeta());
+    }
 }

--- a/server/src/main/java/org/allaymc/server/item/component/ItemGoatHornBaseComponentImpl.java
+++ b/server/src/main/java/org/allaymc/server/item/component/ItemGoatHornBaseComponentImpl.java
@@ -1,0 +1,47 @@
+package org.allaymc.server.item.component;
+
+import org.allaymc.api.entity.interfaces.EntityPlayer;
+import org.allaymc.api.item.ItemStackInitInfo;
+import org.allaymc.api.item.data.GoatHornInstrument;
+import org.allaymc.api.world.sound.CustomSound;
+
+/**
+ * Allay Project 2026/7/12
+ *
+ * @author Miroshka000
+ */
+public class ItemGoatHornBaseComponentImpl extends ItemBaseComponentImpl {
+    public static final String COOLDOWN_CATEGORY = "goat_horn";
+    public static final int COOLDOWN_TICKS = 7 * 20;
+    private static final double SOUND_RANGE_SQUARED = 256 * 256;
+
+    public ItemGoatHornBaseComponentImpl(ItemStackInitInfo initInfo) {
+        super(initInfo);
+    }
+
+    @Override
+    public void rightClickItemInAir(EntityPlayer player) {
+        activateIfReady(player);
+    }
+
+    private void activateIfReady(EntityPlayer player) {
+        if (!player.isCooldownEnd(COOLDOWN_CATEGORY)) {
+            return;
+        }
+
+        player.setCooldown(COOLDOWN_CATEGORY, COOLDOWN_TICKS, true);
+        broadcastSound(player, GoatHornInstrument.fromMeta(getMeta()));
+    }
+
+    private static void broadcastSound(EntityPlayer source, GoatHornInstrument instrument) {
+        var sourcePosition = source.getLocation();
+        var sound = new CustomSound(instrument.getSoundName());
+        for (var viewer : source.getDimension().getPlayers()) {
+            var controlledEntity = viewer.getControlledEntity();
+            if (controlledEntity != null &&
+                controlledEntity.getLocation().distanceSquared(sourcePosition) <= SOUND_RANGE_SQUARED) {
+                viewer.viewSound(sound, sourcePosition, true);
+            }
+        }
+    }
+}

--- a/server/src/main/java/org/allaymc/server/item/type/ItemTypeInitializer.java
+++ b/server/src/main/java/org/allaymc/server/item/type/ItemTypeInitializer.java
@@ -959,6 +959,14 @@ public final class ItemTypeInitializer {
                 .build();
     }
 
+    public static void initGoatHorn() {
+        ItemTypes.GOAT_HORN = AllayItemType
+                .builder(ItemGoatHornStackImpl.class)
+                .vanillaItem(ItemId.GOAT_HORN)
+                .addComponent(ItemGoatHornBaseComponentImpl::new, ItemGoatHornBaseComponentImpl.class)
+                .build();
+    }
+
     public static void initCrossbow() {
         ItemTypes.CROSSBOW = AllayItemType
                 .builder(ItemCrossbowStackImpl.class)

--- a/server/src/main/java/org/allaymc/server/network/processor/ingame/InventoryTransactionPacketProcessor.java
+++ b/server/src/main/java/org/allaymc/server/network/processor/ingame/InventoryTransactionPacketProcessor.java
@@ -9,6 +9,7 @@ import org.allaymc.api.entity.component.EntityLivingComponent;
 import org.allaymc.api.entity.damage.DamageContainer;
 import org.allaymc.api.entity.interfaces.EntityPlayer;
 import org.allaymc.api.eventbus.event.player.*;
+import org.allaymc.api.item.ItemStack;
 import org.allaymc.api.player.Player;
 import org.allaymc.api.world.sound.AttackSound;
 import org.allaymc.server.network.NetworkHelper;
@@ -99,7 +100,6 @@ public class InventoryTransactionPacketProcessor extends PacketProcessor<Invento
                             break;
                         }
 
-                        entity.setUsingItemInAir(false);
                         var sneaking = entity.isSneaking();
                         var useItemOnBlock = !sneaking;
                         var useBlock = !sneaking || itemInHand.getItemType() == AIR;
@@ -124,11 +124,13 @@ public class InventoryTransactionPacketProcessor extends PacketProcessor<Invento
                         }
 
                         if (!player.canPlaceBlocks()) {
+                            handleItemUseInAir(entity, itemInHand);
                             player.viewBlockUpdate(placeBlockPos, 0, dimension.getBlockState(placeBlockPos));
                             break;
                         }
 
                         if (!itemInHand.placeBlock(dimension, placeBlockPos, interactInfo)) {
+                            handleItemUseInAir(entity, itemInHand);
                             var blockStateReplaced = dimension.getBlockState(placeBlockPos);
                             player.viewBlockUpdate(placeBlockPos, 0, blockStateReplaced);
                         }
@@ -141,16 +143,8 @@ public class InventoryTransactionPacketProcessor extends PacketProcessor<Invento
                         }
 
                         if (!entity.isUsingItemInAir()) {
-                            if (itemInHand.canUseItemInAir(entity)) {
-                                if (new PlayerStartUseItemInAirEvent(entity).call()) {
-                                    entity.setUsingItemInAir(true);
-                                }
-                            } else {
-                                if (new PlayerRightClickItemInAirEvent(entity).call()) {
-                                    itemInHand.rightClickItemInAir(entity);
-                                }
-                            }
-                        } else if (entity.isUsingItemInAir()) {
+                            handleItemUseInAir(entity, itemInHand);
+                        } else {
                             entity.setUsingItemInAir(false);
                             var event = new PlayerUseItemInAirEvent(entity, entity.getItemUsingInAirTime());
                             if (event.call()) {
@@ -264,6 +258,27 @@ public class InventoryTransactionPacketProcessor extends PacketProcessor<Invento
             entity.clearItemInHand();
         } else {
             entity.notifyItemInHandChange();
+        }
+    }
+
+    boolean tryStartUsingItemInAir(EntityPlayer player, ItemStack itemStack) {
+        if (!itemStack.canUseItemInAir(player)) {
+            return false;
+        }
+
+        if (new PlayerStartUseItemInAirEvent(player).call()) {
+            player.setUsingItemInAir(true);
+        }
+        return true;
+    }
+
+    void handleItemUseInAir(EntityPlayer player, ItemStack itemStack) {
+        if (tryStartUsingItemInAir(player, itemStack)) {
+            return;
+        }
+
+        if (new PlayerRightClickItemInAirEvent(player).call()) {
+            itemStack.rightClickItemInAir(player);
         }
     }
 

--- a/server/src/test/java/org/allaymc/api/item/data/GoatHornInstrumentTest.java
+++ b/server/src/test/java/org/allaymc/api/item/data/GoatHornInstrumentTest.java
@@ -1,0 +1,67 @@
+package org.allaymc.api.item.data;
+
+import org.allaymc.api.world.sound.SoundNames;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Allay Project 2026/7/12
+ *
+ * @author Miroshka000
+ */
+class GoatHornInstrumentTest {
+
+    @Test
+    void shouldMapAllVanillaVariantsByMeta() {
+        var expected = List.of(
+                GoatHornInstrument.PONDER,
+                GoatHornInstrument.SING,
+                GoatHornInstrument.SEEK,
+                GoatHornInstrument.FEEL,
+                GoatHornInstrument.ADMIRE,
+                GoatHornInstrument.CALL,
+                GoatHornInstrument.YEARN,
+                GoatHornInstrument.DREAM
+        );
+
+        for (int meta = 0; meta < expected.size(); meta++) {
+            assertEquals(expected.get(meta), GoatHornInstrument.fromMeta(meta));
+        }
+    }
+
+    @Test
+    void shouldExposeMatchingSoundNames() {
+        assertEquals(SoundNames.HORN_CALL_0, GoatHornInstrument.PONDER.getSoundName());
+        assertEquals(SoundNames.HORN_CALL_1, GoatHornInstrument.SING.getSoundName());
+        assertEquals(SoundNames.HORN_CALL_2, GoatHornInstrument.SEEK.getSoundName());
+        assertEquals(SoundNames.HORN_CALL_3, GoatHornInstrument.FEEL.getSoundName());
+        assertEquals(SoundNames.HORN_CALL_4, GoatHornInstrument.ADMIRE.getSoundName());
+        assertEquals(SoundNames.HORN_CALL_5, GoatHornInstrument.CALL.getSoundName());
+        assertEquals(SoundNames.HORN_CALL_6, GoatHornInstrument.YEARN.getSoundName());
+        assertEquals(SoundNames.HORN_CALL_7, GoatHornInstrument.DREAM.getSoundName());
+    }
+
+    @Test
+    void shouldFallbackToPonderForInvalidMeta() {
+        assertEquals(GoatHornInstrument.PONDER, GoatHornInstrument.fromMeta(-1));
+        assertEquals(GoatHornInstrument.PONDER, GoatHornInstrument.fromMeta(8));
+        assertEquals(GoatHornInstrument.PONDER, GoatHornInstrument.fromMeta(Integer.MAX_VALUE));
+    }
+
+    @Test
+    void shouldSeparateRegularAndScreamingGoatVariants() {
+        assertFalse(GoatHornInstrument.PONDER.isScreamingGoatVariant());
+        assertFalse(GoatHornInstrument.SING.isScreamingGoatVariant());
+        assertFalse(GoatHornInstrument.SEEK.isScreamingGoatVariant());
+        assertFalse(GoatHornInstrument.FEEL.isScreamingGoatVariant());
+        assertTrue(GoatHornInstrument.ADMIRE.isScreamingGoatVariant());
+        assertTrue(GoatHornInstrument.CALL.isScreamingGoatVariant());
+        assertTrue(GoatHornInstrument.YEARN.isScreamingGoatVariant());
+        assertTrue(GoatHornInstrument.DREAM.isScreamingGoatVariant());
+    }
+}

--- a/server/src/test/java/org/allaymc/server/item/component/ItemGoatHornBaseComponentImplTest.java
+++ b/server/src/test/java/org/allaymc/server/item/component/ItemGoatHornBaseComponentImplTest.java
@@ -1,0 +1,96 @@
+package org.allaymc.server.item.component;
+
+import org.allaymc.api.entity.interfaces.EntityPlayer;
+import org.allaymc.api.item.ItemStackInitInfo;
+import org.allaymc.api.math.location.Location3d;
+import org.allaymc.api.player.Player;
+import org.allaymc.api.world.Dimension;
+import org.allaymc.api.world.sound.CustomSound;
+import org.allaymc.api.world.sound.SoundNames;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Allay Project 2026/7/12
+ *
+ * @author Miroshka000
+ */
+class ItemGoatHornBaseComponentImplTest {
+
+    @Test
+    void shouldUseSharedCooldownCategoryForEveryVariant() {
+        var dimension = mock(Dimension.class);
+        var player = mock(EntityPlayer.class);
+        when(player.getDimension()).thenReturn(dimension);
+        when(player.getLocation()).thenReturn(new Location3d(0, 64, 0, dimension));
+        when(dimension.getPlayers()).thenReturn(Set.of());
+        when(player.isCooldownEnd(ItemGoatHornBaseComponentImpl.COOLDOWN_CATEGORY))
+                .thenReturn(true, false);
+
+        component(0).rightClickItemInAir(player);
+        component(7).rightClickItemInAir(player);
+
+        verify(player, times(2)).isCooldownEnd(ItemGoatHornBaseComponentImpl.COOLDOWN_CATEGORY);
+        verify(player).setCooldown(
+                ItemGoatHornBaseComponentImpl.COOLDOWN_CATEGORY,
+                ItemGoatHornBaseComponentImpl.COOLDOWN_TICKS,
+                true
+        );
+    }
+
+    @Test
+    void shouldPlayVariantSoundOnceAndOnlyWithinRange() {
+        var dimension = mock(Dimension.class);
+        var source = mock(EntityPlayer.class);
+        var sourcePosition = new Location3d(0, 64, 0, dimension);
+        when(source.getDimension()).thenReturn(dimension);
+        when(source.getLocation()).thenReturn(sourcePosition);
+        when(source.isCooldownEnd(ItemGoatHornBaseComponentImpl.COOLDOWN_CATEGORY))
+                .thenReturn(true, false);
+
+        var atLimit = viewerAt(dimension, 256);
+        var outside = viewerAt(dimension, 256.01);
+        when(dimension.getPlayers()).thenReturn(Set.of(atLimit, outside));
+
+        var component = component(5);
+        component.rightClickItemInAir(source);
+        component.rightClickItemInAir(source);
+
+        verify(source).setCooldown(
+                ItemGoatHornBaseComponentImpl.COOLDOWN_CATEGORY,
+                ItemGoatHornBaseComponentImpl.COOLDOWN_TICKS,
+                true
+        );
+        verify(atLimit).viewSound(
+                new CustomSound(SoundNames.HORN_CALL_5),
+                sourcePosition,
+                true
+        );
+        verify(outside, never()).viewSound(any(), any(), anyBoolean());
+    }
+
+    private static ItemGoatHornBaseComponentImpl component(int meta) {
+        return new ItemGoatHornBaseComponentImpl(ItemStackInitInfo.builder()
+                .count(1)
+                .meta(meta)
+                .assignUniqueId(false)
+                .build());
+    }
+
+    private static Player viewerAt(Dimension dimension, double x) {
+        var viewer = mock(Player.class);
+        var controlledEntity = mock(EntityPlayer.class);
+        when(controlledEntity.getLocation()).thenReturn(new Location3d(x, 64, 0, dimension));
+        when(viewer.getControlledEntity()).thenReturn(controlledEntity);
+        return viewer;
+    }
+}

--- a/server/src/test/java/org/allaymc/server/item/type/GoatHornItemTypeTest.java
+++ b/server/src/test/java/org/allaymc/server/item/type/GoatHornItemTypeTest.java
@@ -1,0 +1,49 @@
+package org.allaymc.server.item.type;
+
+import org.allaymc.api.item.data.GoatHornInstrument;
+import org.allaymc.api.item.interfaces.ItemGoatHornStack;
+import org.allaymc.api.item.type.ItemTypes;
+import org.allaymc.api.registry.Registries;
+import org.allaymc.testutils.AllayTestExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+/**
+ * Allay Project 2026/7/12
+ *
+ * @author Miroshka000
+ */
+@ExtendWith(AllayTestExtension.class)
+class GoatHornItemTypeTest {
+
+    @Test
+    void shouldCreateEveryInstrumentVariant() {
+        var horn = assertInstanceOf(ItemGoatHornStack.class, ItemTypes.GOAT_HORN.createItemStack(1));
+
+        for (var instrument : GoatHornInstrument.values()) {
+            horn.setInstrument(instrument);
+            assertEquals(instrument, horn.getInstrument());
+            assertEquals(instrument.getMeta(), horn.getMeta());
+        }
+    }
+
+    @Test
+    void creativeInventoryShouldContainAllEightVariants() {
+        var actualMetas = Registries.CREATIVE_ITEMS.getEntries().stream()
+                .map(entry -> entry.itemStack())
+                .filter(item -> item.getItemType() == ItemTypes.GOAT_HORN)
+                .map(item -> item.getMeta())
+                .collect(Collectors.toSet());
+        var expectedMetas = IntStream.range(0, GoatHornInstrument.values().length)
+                .boxed()
+                .collect(Collectors.toSet());
+
+        assertEquals(expectedMetas, actualMetas);
+    }
+}

--- a/server/src/test/java/org/allaymc/server/network/processor/ingame/InventoryTransactionPacketProcessorTest.java
+++ b/server/src/test/java/org/allaymc/server/network/processor/ingame/InventoryTransactionPacketProcessorTest.java
@@ -1,0 +1,44 @@
+package org.allaymc.server.network.processor.ingame;
+
+import org.allaymc.api.entity.interfaces.EntityPlayer;
+import org.allaymc.api.item.ItemStack;
+import org.allaymc.testutils.AllayTestExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Allay Project 2026/7/12
+ *
+ * @author Miroshka000
+ */
+@ExtendWith(AllayTestExtension.class)
+class InventoryTransactionPacketProcessorTest {
+
+    @Test
+    void shouldStartUsableItemThroughSharedAirUsePath() {
+        var player = mock(EntityPlayer.class);
+        var itemStack = mock(ItemStack.class);
+        when(itemStack.canUseItemInAir(player)).thenReturn(true);
+
+        assertTrue(new InventoryTransactionPacketProcessor().tryStartUsingItemInAir(player, itemStack));
+
+        verify(player).setUsingItemInAir(true);
+    }
+
+    @Test
+    void shouldIgnoreItemsWithoutAirUseBehavior() {
+        var player = mock(EntityPlayer.class);
+        var itemStack = mock(ItemStack.class);
+
+        assertFalse(new InventoryTransactionPacketProcessor().tryStartUsingItemInAir(player, itemStack));
+
+        verify(player, never()).setUsingItemInAir(true);
+    }
+}


### PR DESCRIPTION
## Summary
- Implements all eight goat horn variants and their instrument sounds.
- Broadcasts horn audio up to 256 blocks with a shared 7-second cooldown.
- Uses the native Bedrock hold animation without starting a duplicate server-side use cycle.

## Testing
- `./gradlew :server:compileJava :server:compileTestJava`
- Manually verified in a Minecraft client.

Related to https://github.com/AllayMC/Allay/issues/867 (item 10)