### PR TITLE
fix: handle reordered inventory actions in 1.26.30

### DIFF
--- a/server/src/main/java/org/allaymc/server/network/processor/ingame/InventoryTransactionPacketProcessor.java
+++ b/server/src/main/java/org/allaymc/server/network/processor/ingame/InventoryTransactionPacketProcessor.java
@@ -238,15 +238,24 @@ public class InventoryTransactionPacketProcessor extends PacketProcessor<Invento
                     return;
                 }
 
-                var worldInteractionAction = packet.getActions().getFirst();
-                if (!worldInteractionAction.source().type().equals(InventorySource.Type.WORLD_INTERACTION)) {
-                    log.warn("Expected WORLD_INTERACTION action type, got {}", worldInteractionAction.source().type());
+                // 1.26.30 reordered the action list: WORLD_INTERACTION now comes after CONTAINER.
+                // Instead of assuming a fixed order with getFirst()/getLast(), we search by type.
+                var worldInteractionAction = packet.getActions().stream()
+                        .filter(action -> action.source().type().equals(InventorySource.Type.WORLD_INTERACTION))
+                        .findFirst()
+                        .orElse(null);
+                var containerAction = packet.getActions().stream()
+                        .filter(action -> action.source().type().equals(InventorySource.Type.CONTAINER))
+                        .findFirst()
+                        .orElse(null);
+
+                if (worldInteractionAction == null) {
+                    log.warn("Expected WORLD_INTERACTION action type not found");
                     return;
                 }
 
-                var containerAction = packet.getActions().getLast();
-                if (!containerAction.source().type().equals(InventorySource.Type.CONTAINER)) {
-                    log.warn("Expected CONTAINER action type, got {}", containerAction.source().type());
+                if (containerAction == null) {
+                    log.warn("Expected CONTAINER action type not found");
                     return;
                 }
 


### PR DESCRIPTION
In Bedrock 1.26.30, the action list order changed: WORLD_INTERACTION now comes after CONTAINER instead of before. This caused item drops to fail with:
"Expected WORLD_INTERACTION action type, got CONTAINER"

Instead of assuming a fixed order with getFirst()/getLast(), we now search for actions by type using stream().filter(). This makes the code resilient to any client-side ordering.

<img width="2560" height="1177" alt="IMAGE 2026-07-12 18:05:44" src="https://github.com/user-attachments/assets/425e4c82-aa5f-47c0-81c0-1e92bbda571f" />

Notes: For making this commit, it was used AI with Allay's skill repository.