### PR TITLE
fix: implement boat mechanics

### DIFF
--- a/api/src/main/java/org/allaymc/api/entity/component/EntityBoatBaseComponent.java
+++ b/api/src/main/java/org/allaymc/api/entity/component/EntityBoatBaseComponent.java
@@ -8,18 +8,57 @@ import org.joml.Vector2fc;
  * Boat-specific state and behavior.
  */
 public interface EntityBoatBaseComponent extends EntityBaseComponent, EntityRideableComponent {
+    /**
+     * Gets the visual and material variant of this boat.
+     *
+     * @return the boat variant
+     */
     BoatVariant getBoatVariant();
 
+    /**
+     * Sets the visual and material variant of this boat.
+     *
+     * @param variant the boat variant to set
+     */
     void setBoatVariant(BoatVariant variant);
 
+    /**
+     * Gets the current left paddle rowing animation time.
+     *
+     * @return the left paddle rowing animation time
+     */
     float getRowTimeLeft();
 
+    /**
+     * Gets the current right paddle rowing animation time.
+     *
+     * @return the right paddle rowing animation time
+     */
     float getRowTimeRight();
 
+    /**
+     * Checks whether the left paddle is currently rowing.
+     *
+     * @return {@code true} if the left paddle is rowing, otherwise {@code false}
+     */
     boolean isPaddlingLeft();
 
+    /**
+     * Checks whether the right paddle is currently rowing.
+     *
+     * @return {@code true} if the right paddle is rowing, otherwise {@code false}
+     */
     boolean isPaddlingRight();
 
+    /**
+     * Updates the movement and paddle input supplied by a player. Input from a player who is not
+     * controlling this boat is ignored.
+     *
+     * @param player      the player supplying the input
+     * @param movement    the horizontal movement input
+     * @param paddleLeft  whether the left paddle is active
+     * @param paddleRight whether the right paddle is active
+     */
     void setPaddleInput(EntityPlayer player, Vector2fc movement, boolean paddleLeft, boolean paddleRight);
 
     /**

--- a/api/src/main/java/org/allaymc/api/entity/component/EntityBoatBaseComponent.java
+++ b/api/src/main/java/org/allaymc/api/entity/component/EntityBoatBaseComponent.java
@@ -1,0 +1,29 @@
+package org.allaymc.api.entity.component;
+
+import org.allaymc.api.entity.data.BoatVariant;
+import org.allaymc.api.entity.interfaces.EntityPlayer;
+import org.joml.Vector2fc;
+
+/**
+ * Boat-specific state and behavior.
+ */
+public interface EntityBoatBaseComponent extends EntityBaseComponent, EntityRideableComponent {
+    BoatVariant getBoatVariant();
+
+    void setBoatVariant(BoatVariant variant);
+
+    float getRowTimeLeft();
+
+    float getRowTimeRight();
+
+    boolean isPaddlingLeft();
+
+    boolean isPaddlingRight();
+
+    void setPaddleInput(EntityPlayer player, Vector2fc movement, boolean paddleLeft, boolean paddleRight);
+
+    /**
+     * Repositions passengers after the boat has moved.
+     */
+    void updatePassengerPositions();
+}

--- a/api/src/main/java/org/allaymc/api/entity/component/EntityBoatBaseComponent.java
+++ b/api/src/main/java/org/allaymc/api/entity/component/EntityBoatBaseComponent.java
@@ -7,7 +7,7 @@ import org.joml.Vector2fc;
 /**
  * Boat-specific state and behavior.
  */
-public interface EntityBoatBaseComponent extends EntityBaseComponent, EntityRideableComponent {
+public interface EntityBoatBaseComponent extends EntityBaseComponent {
     /**
      * Gets the visual and material variant of this boat.
      *

--- a/api/src/main/java/org/allaymc/api/entity/component/EntityPlayerBaseComponent.java
+++ b/api/src/main/java/org/allaymc/api/entity/component/EntityPlayerBaseComponent.java
@@ -20,7 +20,7 @@ import java.util.concurrent.ThreadLocalRandom;
 /**
  * Shared component for player entities, covering movement states, respawn data, cooldowns, food, experience, and fishing.
  */
-public interface EntityPlayerBaseComponent extends EntityBaseComponent, ChunkLoader {
+public interface EntityPlayerBaseComponent extends EntityBaseComponent, EntityRiderComponent, ChunkLoader {
 
     int MAX_FOOD_LEVEL = 20;
     float MAX_FOOD_SATURATION_LEVEL = 20;

--- a/api/src/main/java/org/allaymc/api/entity/component/EntityPlayerBaseComponent.java
+++ b/api/src/main/java/org/allaymc/api/entity/component/EntityPlayerBaseComponent.java
@@ -20,7 +20,7 @@ import java.util.concurrent.ThreadLocalRandom;
 /**
  * Shared component for player entities, covering movement states, respawn data, cooldowns, food, experience, and fishing.
  */
-public interface EntityPlayerBaseComponent extends EntityBaseComponent, EntityRiderComponent, ChunkLoader {
+public interface EntityPlayerBaseComponent extends EntityBaseComponent, ChunkLoader {
 
     int MAX_FOOD_LEVEL = 20;
     float MAX_FOOD_SATURATION_LEVEL = 20;

--- a/api/src/main/java/org/allaymc/api/entity/component/EntityRideableComponent.java
+++ b/api/src/main/java/org/allaymc/api/entity/component/EntityRideableComponent.java
@@ -1,0 +1,25 @@
+package org.allaymc.api.entity.component;
+
+import org.allaymc.api.entity.interfaces.EntityPlayer;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.UnmodifiableView;
+
+import java.util.List;
+
+/**
+ * Component for vehicles which can carry player passengers.
+ */
+public interface EntityRideableComponent extends EntityComponent {
+    int getPassengerCapacity();
+
+    @UnmodifiableView
+    List<EntityPlayer> getPassengers();
+
+    @Nullable EntityPlayer getControllingPassenger();
+
+    boolean addPassenger(EntityPlayer passenger);
+
+    boolean removePassenger(EntityPlayer passenger);
+
+    void ejectPassengers();
+}

--- a/api/src/main/java/org/allaymc/api/entity/component/EntityRideableComponent.java
+++ b/api/src/main/java/org/allaymc/api/entity/component/EntityRideableComponent.java
@@ -10,16 +10,46 @@ import java.util.List;
  * Component for vehicles which can carry player passengers.
  */
 public interface EntityRideableComponent extends EntityComponent {
+    /**
+     * Gets the maximum number of passengers this entity can carry.
+     *
+     * @return the passenger capacity
+     */
     int getPassengerCapacity();
 
+    /**
+     * Gets the players currently riding this entity, ordered by seat.
+     *
+     * @return an unmodifiable list of passengers
+     */
     @UnmodifiableView
     List<EntityPlayer> getPassengers();
 
+    /**
+     * Gets the passenger currently controlling this entity.
+     *
+     * @return the controlling passenger, or {@code null} if this entity has no controller
+     */
     @Nullable EntityPlayer getControllingPassenger();
 
+    /**
+     * Attempts to add a player as a passenger.
+     *
+     * @param passenger the player to add
+     * @return {@code true} if the player was added, otherwise {@code false}
+     */
     boolean addPassenger(EntityPlayer passenger);
 
+    /**
+     * Attempts to remove a player from this entity.
+     *
+     * @param passenger the player to remove
+     * @return {@code true} if the player was removed, otherwise {@code false}
+     */
     boolean removePassenger(EntityPlayer passenger);
 
+    /**
+     * Removes all passengers from this entity.
+     */
     void ejectPassengers();
 }

--- a/api/src/main/java/org/allaymc/api/entity/component/EntityRideableComponent.java
+++ b/api/src/main/java/org/allaymc/api/entity/component/EntityRideableComponent.java
@@ -1,7 +1,6 @@
 package org.allaymc.api.entity.component;
 
 import org.allaymc.api.entity.interfaces.EntityPlayer;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.UnmodifiableView;
 
 import java.util.List;
@@ -30,7 +29,7 @@ public interface EntityRideableComponent extends EntityComponent {
      *
      * @return the controlling passenger, or {@code null} if this entity has no controller
      */
-    @Nullable EntityPlayer getControllingPassenger();
+    EntityPlayer getControllingPassenger();
 
     /**
      * Attempts to add a player as a passenger.

--- a/api/src/main/java/org/allaymc/api/entity/component/EntityRiderComponent.java
+++ b/api/src/main/java/org/allaymc/api/entity/component/EntityRiderComponent.java
@@ -1,0 +1,22 @@
+package org.allaymc.api.entity.component;
+
+import org.allaymc.api.entity.Entity;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * State held by an entity which can ride another entity.
+ */
+public interface EntityRiderComponent extends EntityComponent {
+    @Nullable Entity getVehicle();
+
+    default boolean isRiding() {
+        return getVehicle() != null;
+    }
+
+    /**
+     * Updates the other side of a ride relationship. Rideable components are the public entry point.
+     */
+    @ApiStatus.Internal
+    void setVehicle(@Nullable Entity vehicle);
+}

--- a/api/src/main/java/org/allaymc/api/entity/component/EntityRiderComponent.java
+++ b/api/src/main/java/org/allaymc/api/entity/component/EntityRiderComponent.java
@@ -8,14 +8,26 @@ import org.jetbrains.annotations.Nullable;
  * State held by an entity which can ride another entity.
  */
 public interface EntityRiderComponent extends EntityComponent {
+    /**
+     * Gets the entity currently being ridden.
+     *
+     * @return the vehicle, or {@code null} if this entity is not riding
+     */
     @Nullable Entity getVehicle();
 
+    /**
+     * Checks whether this entity is currently riding another entity.
+     *
+     * @return {@code true} if this entity is riding, otherwise {@code false}
+     */
     default boolean isRiding() {
         return getVehicle() != null;
     }
 
     /**
      * Updates the other side of a ride relationship. Rideable components are the public entry point.
+     *
+     * @param vehicle the vehicle being ridden, or {@code null} to clear the relationship
      */
     @ApiStatus.Internal
     void setVehicle(@Nullable Entity vehicle);

--- a/api/src/main/java/org/allaymc/api/entity/component/EntityRiderComponent.java
+++ b/api/src/main/java/org/allaymc/api/entity/component/EntityRiderComponent.java
@@ -2,7 +2,6 @@ package org.allaymc.api.entity.component;
 
 import org.allaymc.api.entity.Entity;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * State held by an entity which can ride another entity.
@@ -13,7 +12,7 @@ public interface EntityRiderComponent extends EntityComponent {
      *
      * @return the vehicle, or {@code null} if this entity is not riding
      */
-    @Nullable Entity getVehicle();
+    Entity getVehicle();
 
     /**
      * Checks whether this entity is currently riding another entity.
@@ -30,5 +29,5 @@ public interface EntityRiderComponent extends EntityComponent {
      * @param vehicle the vehicle being ridden, or {@code null} to clear the relationship
      */
     @ApiStatus.Internal
-    void setVehicle(@Nullable Entity vehicle);
+    void setVehicle(Entity vehicle);
 }

--- a/api/src/main/java/org/allaymc/api/entity/data/BoatVariant.java
+++ b/api/src/main/java/org/allaymc/api/entity/data/BoatVariant.java
@@ -1,0 +1,42 @@
+package org.allaymc.api.entity.data;
+
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Visual/material variants used by vanilla boat entities.
+ */
+public enum BoatVariant {
+    OAK(0),
+    SPRUCE(1),
+    BIRCH(2),
+    JUNGLE(3),
+    ACACIA(4),
+    DARK_OAK(5),
+    MANGROVE(6),
+    BAMBOO(7),
+    CHERRY(8),
+    PALE_OAK(9);
+
+    private final int networkId;
+
+    BoatVariant(int networkId) {
+        this.networkId = networkId;
+    }
+
+    public int getNetworkId() {
+        return networkId;
+    }
+
+    public boolean isRaft() {
+        return this == BAMBOO;
+    }
+
+    public static @Nullable BoatVariant fromNetworkId(int networkId) {
+        for (var variant : values()) {
+            if (variant.networkId == networkId) {
+                return variant;
+            }
+        }
+        return null;
+    }
+}

--- a/api/src/main/java/org/allaymc/api/entity/data/BoatVariant.java
+++ b/api/src/main/java/org/allaymc/api/entity/data/BoatVariant.java
@@ -1,7 +1,5 @@
 package org.allaymc.api.entity.data;
 
-import org.jetbrains.annotations.Nullable;
-
 /**
  * Visual/material variants used by vanilla boat entities.
  */
@@ -31,7 +29,7 @@ public enum BoatVariant {
         return this == BAMBOO;
     }
 
-    public static @Nullable BoatVariant fromNetworkId(int networkId) {
+    public static BoatVariant fromNetworkId(int networkId) {
         for (var variant : values()) {
             if (variant.networkId == networkId) {
                 return variant;

--- a/api/src/main/java/org/allaymc/api/entity/data/EntityLinkType.java
+++ b/api/src/main/java/org/allaymc/api/entity/data/EntityLinkType.java
@@ -1,0 +1,10 @@
+package org.allaymc.api.entity.data;
+
+/**
+ * Describes the relationship between a vehicle and one of its passengers.
+ */
+public enum EntityLinkType {
+    RIDER,
+    PASSENGER,
+    REMOVE
+}

--- a/api/src/main/java/org/allaymc/api/entity/interfaces/EntityBoat.java
+++ b/api/src/main/java/org/allaymc/api/entity/interfaces/EntityBoat.java
@@ -1,7 +1,8 @@
 package org.allaymc.api.entity.interfaces;
 
-import org.allaymc.api.entity.Entity;
+import org.allaymc.api.entity.component.EntityBoatBaseComponent;
+import org.allaymc.api.entity.component.EntityPhysicsComponent;
 
-public interface EntityBoat extends Entity {
+public interface EntityBoat extends EntityLiving, EntityPhysicsComponent, EntityBoatBaseComponent {
 
 }

--- a/api/src/main/java/org/allaymc/api/entity/interfaces/EntityBoat.java
+++ b/api/src/main/java/org/allaymc/api/entity/interfaces/EntityBoat.java
@@ -2,7 +2,8 @@ package org.allaymc.api.entity.interfaces;
 
 import org.allaymc.api.entity.component.EntityBoatBaseComponent;
 import org.allaymc.api.entity.component.EntityPhysicsComponent;
+import org.allaymc.api.entity.component.EntityRideableComponent;
 
-public interface EntityBoat extends EntityLiving, EntityPhysicsComponent, EntityBoatBaseComponent {
+public interface EntityBoat extends EntityLiving, EntityPhysicsComponent, EntityBoatBaseComponent, EntityRideableComponent {
 
 }

--- a/api/src/main/java/org/allaymc/api/entity/interfaces/EntityPlayer.java
+++ b/api/src/main/java/org/allaymc/api/entity/interfaces/EntityPlayer.java
@@ -7,6 +7,7 @@ import org.allaymc.api.container.ContainerTypes;
 import org.allaymc.api.entity.component.EntityContainerHolderComponent;
 import org.allaymc.api.entity.component.EntityPhysicsComponent;
 import org.allaymc.api.entity.component.EntityPlayerBaseComponent;
+import org.allaymc.api.entity.component.EntityRiderComponent;
 import org.allaymc.api.entity.component.EntitySleepableComponent;
 import org.allaymc.api.eventbus.event.player.PlayerDropItemEvent;
 import org.allaymc.api.eventbus.event.player.PlayerItemHeldEvent;
@@ -29,6 +30,7 @@ public interface EntityPlayer extends
         EntityContainerHolderComponent,
         EntityPhysicsComponent,
         EntityPlayerBaseComponent,
+        EntityRiderComponent,
         EntitySleepableComponent {
 
     /**

--- a/api/src/main/java/org/allaymc/api/world/WorldViewer.java
+++ b/api/src/main/java/org/allaymc/api/world/WorldViewer.java
@@ -9,6 +9,7 @@ import org.allaymc.api.entity.action.EntityAction;
 import org.allaymc.api.entity.component.EntityContainerHolderComponent;
 import org.allaymc.api.entity.component.EntityPhysicsComponent;
 import org.allaymc.api.entity.data.EntityAnimation;
+import org.allaymc.api.entity.data.EntityLinkType;
 import org.allaymc.api.entity.effect.EffectInstance;
 import org.allaymc.api.entity.interfaces.EntityPlayer;
 import org.allaymc.api.item.enchantment.EnchantOption;
@@ -71,6 +72,16 @@ public interface WorldViewer extends PrimitiveShapeViewer {
      * @param entity the entity to view
      */
     void viewEntityState(Entity entity);
+
+    /**
+     * Views a vehicle/passenger relationship update.
+     *
+     * @param vehicle the vehicle entity
+     * @param passenger the passenger entity
+     * @param linkType the relationship update type
+     */
+    default void viewEntityLink(Entity vehicle, Entity passenger, EntityLinkType linkType) {
+    }
 
     /**
      * Views the item in the main hand of the entity passed.

--- a/server/src/main/java/org/allaymc/server/entity/component/EntityBaseComponentImpl.java
+++ b/server/src/main/java/org/allaymc/server/entity/component/EntityBaseComponentImpl.java
@@ -12,6 +12,8 @@ import org.allaymc.api.entity.EntityState;
 import org.allaymc.api.entity.action.EntityAction;
 import org.allaymc.api.entity.component.EntityBaseComponent;
 import org.allaymc.api.entity.component.EntityPhysicsComponent;
+import org.allaymc.api.entity.component.EntityRideableComponent;
+import org.allaymc.api.entity.data.EntityLinkType;
 import org.allaymc.api.entity.data.EntityAnimation;
 import org.allaymc.api.entity.interfaces.EntityPlayer;
 import org.allaymc.api.entity.property.type.*;
@@ -475,6 +477,20 @@ public class EntityBaseComponentImpl implements EntityBaseComponent {
         viewers.add(viewer);
         viewer.viewEntity(thisEntity);
         viewer.viewEntityState(thisEntity);
+        if (thisEntity instanceof EntityRideableComponent rideableComponent) {
+            var passengers = rideableComponent.getPassengers();
+            for (int i = 0; i < passengers.size(); i++) {
+                viewer.viewEntityLink(thisEntity, passengers.get(i), i == 0 ? EntityLinkType.RIDER : EntityLinkType.PASSENGER);
+            }
+        }
+        if (thisEntity instanceof EntityPlayer passenger &&
+            passenger.getVehicle() instanceof EntityRideableComponent rideableComponent) {
+            var passengers = rideableComponent.getPassengers();
+            var seat = passengers.indexOf(passenger);
+            if (seat >= 0) {
+                viewer.viewEntityLink(passenger.getVehicle(), passenger, seat == 0 ? EntityLinkType.RIDER : EntityLinkType.PASSENGER);
+            }
+        }
     }
 
     @Override

--- a/server/src/main/java/org/allaymc/server/entity/component/EntityRiderComponentImpl.java
+++ b/server/src/main/java/org/allaymc/server/entity/component/EntityRiderComponentImpl.java
@@ -1,0 +1,20 @@
+package org.allaymc.server.entity.component;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.allaymc.api.entity.Entity;
+import org.allaymc.api.entity.component.EntityRiderComponent;
+import org.allaymc.api.utils.identifier.Identifier;
+
+/**
+ * Stores the vehicle currently ridden by an entity.
+ */
+public class EntityRiderComponentImpl implements EntityRiderComponent {
+
+    @Identifier.Component
+    public static final Identifier IDENTIFIER = new Identifier("minecraft:entity_rider_component");
+
+    @Getter
+    @Setter
+    protected Entity vehicle;
+}

--- a/server/src/main/java/org/allaymc/server/entity/component/player/EntityPlayerBaseComponentImpl.java
+++ b/server/src/main/java/org/allaymc/server/entity/component/player/EntityPlayerBaseComponentImpl.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.allaymc.api.command.CommandSender;
 import org.allaymc.api.container.ContainerTypes;
 import org.allaymc.api.primitiveshape.PrimitiveShape;
+import org.allaymc.api.entity.Entity;
 import org.allaymc.api.entity.EntityInitInfo;
 import org.allaymc.api.entity.action.EntityAction;
 import org.allaymc.api.entity.component.EntityPlayerBaseComponent;
@@ -95,6 +96,8 @@ public class EntityPlayerBaseComponentImpl extends EntityBaseComponentImpl imple
     @Getter
     protected Player controller;
     @Getter
+    protected Entity vehicle;
+    @Getter
     protected GameMode gameMode;
     protected boolean phantom;
     @Getter
@@ -121,6 +124,11 @@ public class EntityPlayerBaseComponentImpl extends EntityBaseComponentImpl imple
     protected long startUsingItemInAirTime;
 
     protected Map<String, Long> cooldowns;
+
+    @Override
+    public void setVehicle(Entity vehicle) {
+        this.vehicle = vehicle;
+    }
 
     @Getter
     protected String scoreTag;

--- a/server/src/main/java/org/allaymc/server/entity/component/player/EntityPlayerBaseComponentImpl.java
+++ b/server/src/main/java/org/allaymc/server/entity/component/player/EntityPlayerBaseComponentImpl.java
@@ -6,7 +6,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.allaymc.api.command.CommandSender;
 import org.allaymc.api.container.ContainerTypes;
 import org.allaymc.api.primitiveshape.PrimitiveShape;
-import org.allaymc.api.entity.Entity;
 import org.allaymc.api.entity.EntityInitInfo;
 import org.allaymc.api.entity.action.EntityAction;
 import org.allaymc.api.entity.component.EntityPlayerBaseComponent;
@@ -96,8 +95,6 @@ public class EntityPlayerBaseComponentImpl extends EntityBaseComponentImpl imple
     @Getter
     protected Player controller;
     @Getter
-    protected Entity vehicle;
-    @Getter
     protected GameMode gameMode;
     protected boolean phantom;
     @Getter
@@ -124,11 +121,6 @@ public class EntityPlayerBaseComponentImpl extends EntityBaseComponentImpl imple
     protected long startUsingItemInAirTime;
 
     protected Map<String, Long> cooldowns;
-
-    @Override
-    public void setVehicle(Entity vehicle) {
-        this.vehicle = vehicle;
-    }
 
     @Getter
     protected String scoreTag;

--- a/server/src/main/java/org/allaymc/server/entity/component/vehicle/BoatItemHelper.java
+++ b/server/src/main/java/org/allaymc/server/entity/component/vehicle/BoatItemHelper.java
@@ -1,0 +1,24 @@
+package org.allaymc.server.entity.component.vehicle;
+
+import lombok.experimental.UtilityClass;
+import org.allaymc.api.entity.data.BoatVariant;
+import org.allaymc.api.item.ItemStack;
+import org.allaymc.api.item.type.ItemTypes;
+
+@UtilityClass
+final class BoatItemHelper {
+    static ItemStack createItem(BoatVariant variant) {
+        return switch (variant) {
+            case OAK -> ItemTypes.OAK_BOAT.createItemStack();
+            case SPRUCE -> ItemTypes.SPRUCE_BOAT.createItemStack();
+            case BIRCH -> ItemTypes.BIRCH_BOAT.createItemStack();
+            case JUNGLE -> ItemTypes.JUNGLE_BOAT.createItemStack();
+            case ACACIA -> ItemTypes.ACACIA_BOAT.createItemStack();
+            case DARK_OAK -> ItemTypes.DARK_OAK_BOAT.createItemStack();
+            case MANGROVE -> ItemTypes.MANGROVE_BOAT.createItemStack();
+            case BAMBOO -> ItemTypes.BAMBOO_RAFT.createItemStack();
+            case CHERRY -> ItemTypes.CHERRY_BOAT.createItemStack();
+            case PALE_OAK -> ItemTypes.PALE_OAK_BOAT.createItemStack();
+        };
+    }
+}

--- a/server/src/main/java/org/allaymc/server/entity/component/vehicle/EntityBoatBaseComponentImpl.java
+++ b/server/src/main/java/org/allaymc/server/entity/component/vehicle/EntityBoatBaseComponentImpl.java
@@ -1,0 +1,319 @@
+package org.allaymc.server.entity.component.vehicle;
+
+import org.allaymc.api.entity.EntityInitInfo;
+import org.allaymc.api.entity.component.EntityBoatBaseComponent;
+import org.allaymc.api.entity.component.EntityPhysicsComponent;
+import org.allaymc.api.entity.data.BoatVariant;
+import org.allaymc.api.entity.data.EntityLinkType;
+import org.allaymc.api.entity.interfaces.EntityBoat;
+import org.allaymc.api.entity.interfaces.EntityPlayer;
+import org.allaymc.api.eventbus.EventHandler;
+import org.allaymc.api.item.ItemStack;
+import org.allaymc.api.math.location.Location3d;
+import org.allaymc.api.player.GameMode;
+import org.allaymc.server.component.annotation.ComponentObject;
+import org.allaymc.server.component.annotation.Dependency;
+import org.allaymc.server.entity.component.EntityBaseComponentImpl;
+import org.allaymc.server.entity.component.event.CEntityBeforeTeleportEvent;
+import org.allaymc.server.entity.component.event.CEntityDieEvent;
+import org.allaymc.server.entity.component.event.CEntityLoadNBTEvent;
+import org.allaymc.server.entity.component.event.CEntitySaveNBTEvent;
+import org.allaymc.server.entity.component.event.CEntityTickEvent;
+import org.joml.Vector2f;
+import org.joml.Vector2fc;
+import org.joml.Vector3d;
+import org.joml.primitives.AABBd;
+import org.joml.primitives.AABBdc;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Base behavior for ordinary boats and bamboo rafts.
+ */
+public class EntityBoatBaseComponentImpl extends EntityBaseComponentImpl implements EntityBoatBaseComponent {
+    protected static final String TAG_VARIANT = "Variant";
+    protected static final int INPUT_EXPIRY_TICKS = 2;
+    protected static final double MAX_HORIZONTAL_SPEED = 0.4;
+
+    @ComponentObject
+    protected EntityBoat boat;
+    @Dependency
+    protected EntityPhysicsComponent physicsComponent;
+
+    protected BoatVariant variant = BoatVariant.OAK;
+    protected final List<EntityPlayer> passengers = new ArrayList<>(2);
+    protected final Vector2f movementInput = new Vector2f();
+    protected boolean paddleLeft;
+    protected boolean paddleRight;
+    protected float rowTimeLeft;
+    protected float rowTimeRight;
+    protected long lastInputTick = Long.MIN_VALUE;
+
+    public EntityBoatBaseComponentImpl(EntityInitInfo info) {
+        super(info);
+    }
+
+    @Override
+    public AABBdc getBaseAABB() {
+        return new AABBd(-0.7, 0, -0.7, 0.7, 0.455, 0.7);
+    }
+
+    @Override
+    public BoatVariant getBoatVariant() {
+        return variant;
+    }
+
+    @Override
+    public void setBoatVariant(BoatVariant variant) {
+        this.variant = Objects.requireNonNull(variant, "variant");
+        broadcastState();
+        updatePassengerPositions();
+    }
+
+    @Override
+    public float getRowTimeLeft() {
+        return rowTimeLeft;
+    }
+
+    @Override
+    public float getRowTimeRight() {
+        return rowTimeRight;
+    }
+
+    @Override
+    public boolean isPaddlingLeft() {
+        return paddleLeft;
+    }
+
+    @Override
+    public boolean isPaddlingRight() {
+        return paddleRight;
+    }
+
+    @Override
+    public int getPassengerCapacity() {
+        return 2;
+    }
+
+    @Override
+    public synchronized List<EntityPlayer> getPassengers() {
+        return List.copyOf(passengers);
+    }
+
+    @Override
+    public synchronized EntityPlayer getControllingPassenger() {
+        return passengers.isEmpty() ? null : passengers.getFirst();
+    }
+
+    @Override
+    public synchronized boolean addPassenger(EntityPlayer passenger) {
+        if (passenger == null || passenger.getGameMode() == GameMode.SPECTATOR ||
+            passenger.getDimension() != getDimension() || passenger.isRiding() ||
+            passengers.contains(passenger) || passengers.size() >= getPassengerCapacity()) {
+            return false;
+        }
+
+        passengers.add(passenger);
+        passenger.setVehicle(boat);
+        broadcastLink(passenger, passengers.size() == 1 ? EntityLinkType.RIDER : EntityLinkType.PASSENGER);
+        broadcastState();
+        updatePassengerPositions();
+        return true;
+    }
+
+    @Override
+    public synchronized boolean removePassenger(EntityPlayer passenger) {
+        var index = passengers.indexOf(passenger);
+        if (index < 0) {
+            return false;
+        }
+
+        broadcastLink(passenger, EntityLinkType.REMOVE);
+        passengers.remove(index);
+        passenger.setVehicle(null);
+        movePassengerToDismountPosition(passenger);
+
+        if (index == 0 && !passengers.isEmpty()) {
+            var promoted = passengers.getFirst();
+            broadcastLink(promoted, EntityLinkType.REMOVE);
+            broadcastLink(promoted, EntityLinkType.RIDER);
+        }
+
+        clearInput();
+        broadcastState();
+        updatePassengerPositions();
+        return true;
+    }
+
+    @Override
+    public synchronized void ejectPassengers() {
+        for (var passenger : List.copyOf(passengers)) {
+            removePassenger(passenger);
+        }
+    }
+
+    @Override
+    public boolean onInteract(EntityPlayer player, ItemStack itemStack) {
+        return addPassenger(player);
+    }
+
+    @Override
+    public synchronized void setPaddleInput(EntityPlayer player, Vector2fc movement, boolean paddleLeft, boolean paddleRight) {
+        if (player != getControllingPassenger()) {
+            return;
+        }
+
+        this.movementInput.set(movement == null ? new Vector2f() : movement);
+        this.paddleLeft = paddleLeft;
+        this.paddleRight = paddleRight;
+        this.lastInputTick = getTick();
+    }
+
+    @EventHandler
+    protected synchronized void onTick(CEntityTickEvent event) {
+        if (getControllingPassenger() == null || getTick() - lastInputTick > INPUT_EXPIRY_TICKS) {
+            clearInput();
+        }
+
+        applyControlInput();
+        updateRowingAnimation();
+    }
+
+    protected void applyControlInput() {
+        if (getControllingPassenger() == null) {
+            return;
+        }
+
+        var forward = Math.clamp(movementInput.y(), -1f, 1f);
+        var steer = Math.clamp(movementInput.x(), -1f, 1f);
+        if (Math.abs(forward) < 0.001f && Math.abs(steer) < 0.001f) {
+            if (paddleLeft && paddleRight) {
+                forward = 1;
+            } else if (paddleLeft != paddleRight) {
+                steer = paddleRight ? 1 : -1;
+            }
+        }
+
+        var location = new Location3d(getLocation());
+        if (Math.abs(steer) > 0.001f) {
+            location.yaw += steer;
+            trySetLocation(location);
+        }
+
+        double acceleration = forward >= 0 ? 0.04 * forward : 0.02 * forward;
+        if (Math.abs(forward) < 0.001f && paddleLeft != paddleRight) {
+            acceleration = 0.005;
+        }
+        if (Math.abs(acceleration) < 0.00001) {
+            return;
+        }
+
+        var yaw = Math.toRadians(location.yaw());
+        var motion = physicsComponent.getMotion().add(
+                -Math.sin(yaw) * acceleration,
+                0,
+                Math.cos(yaw) * acceleration,
+                new Vector3d()
+        );
+        var horizontalSpeed = Math.hypot(motion.x(), motion.z());
+        if (horizontalSpeed > MAX_HORIZONTAL_SPEED) {
+            var scale = MAX_HORIZONTAL_SPEED / horizontalSpeed;
+            motion.x *= scale;
+            motion.z *= scale;
+        }
+        physicsComponent.setMotion(motion);
+    }
+
+    protected void updateRowingAnimation() {
+        var oldLeft = rowTimeLeft;
+        var oldRight = rowTimeRight;
+        rowTimeLeft = paddleLeft ? rowTimeLeft + (float) (Math.PI / 8) : 0;
+        rowTimeRight = paddleRight ? rowTimeRight + (float) (Math.PI / 8) : 0;
+        if (Float.compare(oldLeft, rowTimeLeft) != 0 || Float.compare(oldRight, rowTimeRight) != 0) {
+            broadcastState();
+        }
+    }
+
+    protected void clearInput() {
+        movementInput.zero();
+        paddleLeft = false;
+        paddleRight = false;
+    }
+
+    @Override
+    public synchronized void updatePassengerPositions() {
+        if (passengers.isEmpty()) {
+            return;
+        }
+
+        for (int i = 0; i < passengers.size(); i++) {
+            var localX = passengers.size() == 1 ? 0 : (i == 0 ? 0.2 : -0.6);
+            var localY = variant.isRaft() ? 0.1 : -0.2;
+            var yaw = Math.toRadians(getLocation().yaw());
+            var x = getLocation().x() + localX * Math.cos(yaw);
+            var z = getLocation().z() + localX * Math.sin(yaw);
+            var passenger = passengers.get(i);
+            passenger.trySetLocation(new Location3d(
+                    x, getLocation().y() + localY, z,
+                    passenger.getLocation().pitch(), getLocation().yaw() - 90,
+                    getDimension()
+            ));
+        }
+    }
+
+    protected void movePassengerToDismountPosition(EntityPlayer passenger) {
+        var yaw = Math.toRadians(getLocation().yaw());
+        var sideX = Math.cos(yaw) * 1.5;
+        var sideZ = Math.sin(yaw) * 1.5;
+        var candidates = new double[][]{
+                {getLocation().x() + sideX, getLocation().y(), getLocation().z() + sideZ},
+                {getLocation().x() - sideX, getLocation().y(), getLocation().z() - sideZ},
+                {getLocation().x() + sideZ, getLocation().y(), getLocation().z() - sideX},
+                {getLocation().x() - sideZ, getLocation().y(), getLocation().z() + sideX}
+        };
+        for (var candidate : candidates) {
+            var aabb = passenger.getAABB().translate(candidate[0], candidate[1], candidate[2], new AABBd());
+            if (getDimension().getCollidingBlockStates(aabb) == null && !aabb.intersectsAABB(getOffsetAABB())) {
+                passenger.trySetLocation(new Location3d(candidate[0], candidate[1], candidate[2],
+                        passenger.getLocation().pitch(), passenger.getLocation().yaw(), getDimension()));
+                return;
+            }
+        }
+        passenger.trySetLocation(new Location3d(getLocation().x(), getLocation().y() + 0.6, getLocation().z(),
+                passenger.getLocation().pitch(), passenger.getLocation().yaw(), getDimension()));
+    }
+
+    protected void broadcastLink(EntityPlayer passenger, EntityLinkType linkType) {
+        var viewers = new LinkedHashSet<>(getViewers());
+        if (passenger.getController() != null) {
+            viewers.add(passenger.getController());
+        }
+        viewers.forEach(viewer -> viewer.viewEntityLink(boat, passenger, linkType));
+    }
+
+    @EventHandler
+    protected void onSaveNBT(CEntitySaveNBTEvent event) {
+        event.getNbt().putInt(TAG_VARIANT, variant.getNetworkId());
+    }
+
+    @EventHandler
+    protected void onLoadNBT(CEntityLoadNBTEvent event) {
+        if (event.getNbt().containsKey(TAG_VARIANT)) {
+            var loaded = BoatVariant.fromNetworkId(event.getNbt().getInt(TAG_VARIANT));
+            variant = loaded == null ? BoatVariant.OAK : loaded;
+        }
+    }
+
+    @EventHandler
+    protected void onBeforeTeleport(CEntityBeforeTeleportEvent event) {
+        ejectPassengers();
+    }
+
+    @EventHandler
+    protected void onDie(CEntityDieEvent event) {
+        ejectPassengers();
+    }
+}

--- a/server/src/main/java/org/allaymc/server/entity/component/vehicle/EntityBoatBaseComponentImpl.java
+++ b/server/src/main/java/org/allaymc/server/entity/component/vehicle/EntityBoatBaseComponentImpl.java
@@ -1,5 +1,6 @@
 package org.allaymc.server.entity.component.vehicle;
 
+import lombok.Getter;
 import org.allaymc.api.entity.EntityInitInfo;
 import org.allaymc.api.entity.component.EntityBoatBaseComponent;
 import org.allaymc.api.entity.component.EntityPhysicsComponent;
@@ -43,12 +44,17 @@ public class EntityBoatBaseComponentImpl extends EntityBaseComponentImpl impleme
     @Dependency
     protected EntityPhysicsComponent physicsComponent;
 
-    protected BoatVariant variant = BoatVariant.OAK;
+    @Getter
+    protected BoatVariant boatVariant = BoatVariant.OAK;
     protected final List<EntityPlayer> passengers = new ArrayList<>(2);
     protected final Vector2f movementInput = new Vector2f();
-    protected boolean paddleLeft;
-    protected boolean paddleRight;
+    @Getter
+    protected boolean paddlingLeft;
+    @Getter
+    protected boolean paddlingRight;
+    @Getter
     protected float rowTimeLeft;
+    @Getter
     protected float rowTimeRight;
     protected long lastInputTick = Long.MIN_VALUE;
 
@@ -62,35 +68,10 @@ public class EntityBoatBaseComponentImpl extends EntityBaseComponentImpl impleme
     }
 
     @Override
-    public BoatVariant getBoatVariant() {
-        return variant;
-    }
-
-    @Override
     public void setBoatVariant(BoatVariant variant) {
-        this.variant = Objects.requireNonNull(variant, "variant");
+        this.boatVariant = Objects.requireNonNull(variant, "variant");
         broadcastState();
         updatePassengerPositions();
-    }
-
-    @Override
-    public float getRowTimeLeft() {
-        return rowTimeLeft;
-    }
-
-    @Override
-    public float getRowTimeRight() {
-        return rowTimeRight;
-    }
-
-    @Override
-    public boolean isPaddlingLeft() {
-        return paddleLeft;
-    }
-
-    @Override
-    public boolean isPaddlingRight() {
-        return paddleRight;
     }
 
     @Override
@@ -167,8 +148,8 @@ public class EntityBoatBaseComponentImpl extends EntityBaseComponentImpl impleme
         }
 
         this.movementInput.set(movement == null ? new Vector2f() : movement);
-        this.paddleLeft = paddleLeft;
-        this.paddleRight = paddleRight;
+        this.paddlingLeft = paddleLeft;
+        this.paddlingRight = paddleRight;
         this.lastInputTick = getTick();
     }
 
@@ -190,10 +171,10 @@ public class EntityBoatBaseComponentImpl extends EntityBaseComponentImpl impleme
         var forward = Math.clamp(movementInput.y(), -1f, 1f);
         var steer = Math.clamp(movementInput.x(), -1f, 1f);
         if (Math.abs(forward) < 0.001f && Math.abs(steer) < 0.001f) {
-            if (paddleLeft && paddleRight) {
+            if (paddlingLeft && paddlingRight) {
                 forward = 1;
-            } else if (paddleLeft != paddleRight) {
-                steer = paddleRight ? 1 : -1;
+            } else if (paddlingLeft != paddlingRight) {
+                steer = paddlingRight ? 1 : -1;
             }
         }
 
@@ -204,7 +185,7 @@ public class EntityBoatBaseComponentImpl extends EntityBaseComponentImpl impleme
         }
 
         double acceleration = forward >= 0 ? 0.04 * forward : 0.02 * forward;
-        if (Math.abs(forward) < 0.001f && paddleLeft != paddleRight) {
+        if (Math.abs(forward) < 0.001f && paddlingLeft != paddlingRight) {
             acceleration = 0.005;
         }
         if (Math.abs(acceleration) < 0.00001) {
@@ -230,8 +211,8 @@ public class EntityBoatBaseComponentImpl extends EntityBaseComponentImpl impleme
     protected void updateRowingAnimation() {
         var oldLeft = rowTimeLeft;
         var oldRight = rowTimeRight;
-        rowTimeLeft = paddleLeft ? rowTimeLeft + (float) (Math.PI / 8) : 0;
-        rowTimeRight = paddleRight ? rowTimeRight + (float) (Math.PI / 8) : 0;
+        rowTimeLeft = paddlingLeft ? rowTimeLeft + (float) (Math.PI / 8) : 0;
+        rowTimeRight = paddlingRight ? rowTimeRight + (float) (Math.PI / 8) : 0;
         if (Float.compare(oldLeft, rowTimeLeft) != 0 || Float.compare(oldRight, rowTimeRight) != 0) {
             broadcastState();
         }
@@ -239,8 +220,8 @@ public class EntityBoatBaseComponentImpl extends EntityBaseComponentImpl impleme
 
     protected void clearInput() {
         movementInput.zero();
-        paddleLeft = false;
-        paddleRight = false;
+        paddlingLeft = false;
+        paddlingRight = false;
     }
 
     @Override
@@ -251,7 +232,7 @@ public class EntityBoatBaseComponentImpl extends EntityBaseComponentImpl impleme
 
         for (int i = 0; i < passengers.size(); i++) {
             var localX = passengers.size() == 1 ? 0 : (i == 0 ? 0.2 : -0.6);
-            var localY = variant.isRaft() ? 0.1 : -0.2;
+            var localY = boatVariant.isRaft() ? 0.1 : -0.2;
             var yaw = Math.toRadians(getLocation().yaw());
             var x = getLocation().x() + localX * Math.cos(yaw);
             var z = getLocation().z() + localX * Math.sin(yaw);
@@ -296,14 +277,14 @@ public class EntityBoatBaseComponentImpl extends EntityBaseComponentImpl impleme
 
     @EventHandler
     protected void onSaveNBT(CEntitySaveNBTEvent event) {
-        event.getNbt().putInt(TAG_VARIANT, variant.getNetworkId());
+        event.getNbt().putInt(TAG_VARIANT, boatVariant.getNetworkId());
     }
 
     @EventHandler
     protected void onLoadNBT(CEntityLoadNBTEvent event) {
         if (event.getNbt().containsKey(TAG_VARIANT)) {
             var loaded = BoatVariant.fromNetworkId(event.getNbt().getInt(TAG_VARIANT));
-            variant = loaded == null ? BoatVariant.OAK : loaded;
+            boatVariant = loaded == null ? BoatVariant.OAK : loaded;
         }
     }
 

--- a/server/src/main/java/org/allaymc/server/entity/component/vehicle/EntityBoatBaseComponentImpl.java
+++ b/server/src/main/java/org/allaymc/server/entity/component/vehicle/EntityBoatBaseComponentImpl.java
@@ -4,19 +4,14 @@ import lombok.Getter;
 import org.allaymc.api.entity.EntityInitInfo;
 import org.allaymc.api.entity.component.EntityBoatBaseComponent;
 import org.allaymc.api.entity.component.EntityPhysicsComponent;
+import org.allaymc.api.entity.component.EntityRideableComponent;
 import org.allaymc.api.entity.data.BoatVariant;
-import org.allaymc.api.entity.data.EntityLinkType;
-import org.allaymc.api.entity.interfaces.EntityBoat;
 import org.allaymc.api.entity.interfaces.EntityPlayer;
 import org.allaymc.api.eventbus.EventHandler;
 import org.allaymc.api.item.ItemStack;
 import org.allaymc.api.math.location.Location3d;
-import org.allaymc.api.player.GameMode;
-import org.allaymc.server.component.annotation.ComponentObject;
 import org.allaymc.server.component.annotation.Dependency;
 import org.allaymc.server.entity.component.EntityBaseComponentImpl;
-import org.allaymc.server.entity.component.event.CEntityBeforeTeleportEvent;
-import org.allaymc.server.entity.component.event.CEntityDieEvent;
 import org.allaymc.server.entity.component.event.CEntityLoadNBTEvent;
 import org.allaymc.server.entity.component.event.CEntitySaveNBTEvent;
 import org.allaymc.server.entity.component.event.CEntityTickEvent;
@@ -26,9 +21,6 @@ import org.joml.Vector3d;
 import org.joml.primitives.AABBd;
 import org.joml.primitives.AABBdc;
 
-import java.util.ArrayList;
-import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Objects;
 
 /**
@@ -39,14 +31,13 @@ public class EntityBoatBaseComponentImpl extends EntityBaseComponentImpl impleme
     protected static final int INPUT_EXPIRY_TICKS = 2;
     protected static final double MAX_HORIZONTAL_SPEED = 0.4;
 
-    @ComponentObject
-    protected EntityBoat boat;
     @Dependency
     protected EntityPhysicsComponent physicsComponent;
+    @Dependency
+    protected EntityRideableComponent rideableComponent;
 
     @Getter
     protected BoatVariant boatVariant = BoatVariant.OAK;
-    protected final List<EntityPlayer> passengers = new ArrayList<>(2);
     protected final Vector2f movementInput = new Vector2f();
     @Getter
     protected boolean paddlingLeft;
@@ -75,75 +66,13 @@ public class EntityBoatBaseComponentImpl extends EntityBaseComponentImpl impleme
     }
 
     @Override
-    public int getPassengerCapacity() {
-        return 2;
-    }
-
-    @Override
-    public synchronized List<EntityPlayer> getPassengers() {
-        return List.copyOf(passengers);
-    }
-
-    @Override
-    public synchronized EntityPlayer getControllingPassenger() {
-        return passengers.isEmpty() ? null : passengers.getFirst();
-    }
-
-    @Override
-    public synchronized boolean addPassenger(EntityPlayer passenger) {
-        if (passenger == null || passenger.getGameMode() == GameMode.SPECTATOR ||
-            passenger.getDimension() != getDimension() || passenger.isRiding() ||
-            passengers.contains(passenger) || passengers.size() >= getPassengerCapacity()) {
-            return false;
-        }
-
-        passengers.add(passenger);
-        passenger.setVehicle(boat);
-        broadcastLink(passenger, passengers.size() == 1 ? EntityLinkType.RIDER : EntityLinkType.PASSENGER);
-        broadcastState();
-        updatePassengerPositions();
-        return true;
-    }
-
-    @Override
-    public synchronized boolean removePassenger(EntityPlayer passenger) {
-        var index = passengers.indexOf(passenger);
-        if (index < 0) {
-            return false;
-        }
-
-        broadcastLink(passenger, EntityLinkType.REMOVE);
-        passengers.remove(index);
-        passenger.setVehicle(null);
-        movePassengerToDismountPosition(passenger);
-
-        if (index == 0 && !passengers.isEmpty()) {
-            var promoted = passengers.getFirst();
-            broadcastLink(promoted, EntityLinkType.REMOVE);
-            broadcastLink(promoted, EntityLinkType.RIDER);
-        }
-
-        clearInput();
-        broadcastState();
-        updatePassengerPositions();
-        return true;
-    }
-
-    @Override
-    public synchronized void ejectPassengers() {
-        for (var passenger : List.copyOf(passengers)) {
-            removePassenger(passenger);
-        }
-    }
-
-    @Override
     public boolean onInteract(EntityPlayer player, ItemStack itemStack) {
-        return addPassenger(player);
+        return rideableComponent.addPassenger(player);
     }
 
     @Override
-    public synchronized void setPaddleInput(EntityPlayer player, Vector2fc movement, boolean paddleLeft, boolean paddleRight) {
-        if (player != getControllingPassenger()) {
+    public void setPaddleInput(EntityPlayer player, Vector2fc movement, boolean paddleLeft, boolean paddleRight) {
+        if (player != rideableComponent.getControllingPassenger()) {
             return;
         }
 
@@ -154,8 +83,8 @@ public class EntityBoatBaseComponentImpl extends EntityBaseComponentImpl impleme
     }
 
     @EventHandler
-    protected synchronized void onTick(CEntityTickEvent event) {
-        if (getControllingPassenger() == null || getTick() - lastInputTick > INPUT_EXPIRY_TICKS) {
+    protected void onTick(CEntityTickEvent event) {
+        if (rideableComponent.getControllingPassenger() == null || getTick() - lastInputTick > INPUT_EXPIRY_TICKS) {
             clearInput();
         }
 
@@ -164,7 +93,7 @@ public class EntityBoatBaseComponentImpl extends EntityBaseComponentImpl impleme
     }
 
     protected void applyControlInput() {
-        if (getControllingPassenger() == null) {
+        if (rideableComponent.getControllingPassenger() == null) {
             return;
         }
 
@@ -225,7 +154,8 @@ public class EntityBoatBaseComponentImpl extends EntityBaseComponentImpl impleme
     }
 
     @Override
-    public synchronized void updatePassengerPositions() {
+    public void updatePassengerPositions() {
+        var passengers = rideableComponent.getPassengers();
         if (passengers.isEmpty()) {
             return;
         }
@@ -245,36 +175,6 @@ public class EntityBoatBaseComponentImpl extends EntityBaseComponentImpl impleme
         }
     }
 
-    protected void movePassengerToDismountPosition(EntityPlayer passenger) {
-        var yaw = Math.toRadians(getLocation().yaw());
-        var sideX = Math.cos(yaw) * 1.5;
-        var sideZ = Math.sin(yaw) * 1.5;
-        var candidates = new double[][]{
-                {getLocation().x() + sideX, getLocation().y(), getLocation().z() + sideZ},
-                {getLocation().x() - sideX, getLocation().y(), getLocation().z() - sideZ},
-                {getLocation().x() + sideZ, getLocation().y(), getLocation().z() - sideX},
-                {getLocation().x() - sideZ, getLocation().y(), getLocation().z() + sideX}
-        };
-        for (var candidate : candidates) {
-            var aabb = passenger.getAABB().translate(candidate[0], candidate[1], candidate[2], new AABBd());
-            if (getDimension().getCollidingBlockStates(aabb) == null && !aabb.intersectsAABB(getOffsetAABB())) {
-                passenger.trySetLocation(new Location3d(candidate[0], candidate[1], candidate[2],
-                        passenger.getLocation().pitch(), passenger.getLocation().yaw(), getDimension()));
-                return;
-            }
-        }
-        passenger.trySetLocation(new Location3d(getLocation().x(), getLocation().y() + 0.6, getLocation().z(),
-                passenger.getLocation().pitch(), passenger.getLocation().yaw(), getDimension()));
-    }
-
-    protected void broadcastLink(EntityPlayer passenger, EntityLinkType linkType) {
-        var viewers = new LinkedHashSet<>(getViewers());
-        if (passenger.getController() != null) {
-            viewers.add(passenger.getController());
-        }
-        viewers.forEach(viewer -> viewer.viewEntityLink(boat, passenger, linkType));
-    }
-
     @EventHandler
     protected void onSaveNBT(CEntitySaveNBTEvent event) {
         event.getNbt().putInt(TAG_VARIANT, boatVariant.getNetworkId());
@@ -288,13 +188,4 @@ public class EntityBoatBaseComponentImpl extends EntityBaseComponentImpl impleme
         }
     }
 
-    @EventHandler
-    protected void onBeforeTeleport(CEntityBeforeTeleportEvent event) {
-        ejectPassengers();
-    }
-
-    @EventHandler
-    protected void onDie(CEntityDieEvent event) {
-        ejectPassengers();
-    }
 }

--- a/server/src/main/java/org/allaymc/server/entity/component/vehicle/EntityBoatLivingComponentImpl.java
+++ b/server/src/main/java/org/allaymc/server/entity/component/vehicle/EntityBoatLivingComponentImpl.java
@@ -1,0 +1,91 @@
+package org.allaymc.server.entity.component.vehicle;
+
+import org.allaymc.api.entity.damage.DamageContainer;
+import org.allaymc.api.entity.action.SimpleEntityAction;
+import org.allaymc.api.entity.interfaces.EntityBoat;
+import org.allaymc.api.entity.interfaces.EntityPlayer;
+import org.allaymc.api.eventbus.event.entity.EntityDamageEvent;
+import org.allaymc.api.player.GameMode;
+import org.allaymc.api.world.gamerule.GameRule;
+import org.allaymc.server.component.annotation.ComponentObject;
+import org.allaymc.server.entity.component.EntityLivingComponentImpl;
+
+/**
+ * Damage/break behavior for boats without applying mob death semantics.
+ */
+public class EntityBoatLivingComponentImpl extends EntityLivingComponentImpl {
+    protected static final float BREAK_DAMAGE = 4;
+
+    @ComponentObject
+    protected EntityBoat boat;
+    protected float accumulatedDamage;
+
+    public EntityBoatLivingComponentImpl() {
+        setMaxHealth(BREAK_DAMAGE);
+    }
+
+    @Override
+    public boolean attack(DamageContainer damage, boolean ignoreCoolDown) {
+        if (!thisEntity.isAlive() || !canBeAttacked(damage) ||
+            !checkAndUpdateCoolDown(damage, ignoreCoolDown || isCreativeAttacker(damage))) {
+            return false;
+        }
+
+        var event = new EntityDamageEvent(thisEntity, damage);
+        if (!event.call()) {
+            return false;
+        }
+        damage = event.getDamageContainer();
+        this.lastDamage = damage;
+        this.lastDamageTime = baseComponent.getTick();
+        thisEntity.applyAction(SimpleEntityAction.HURT);
+
+        if (isCreativeAttacker(damage)) {
+            breakBoat(false);
+            return true;
+        }
+
+        accumulatedDamage += Math.max(0, damage.getFinalDamage());
+        thisEntity.broadcastState();
+        if (accumulatedDamage >= BREAK_DAMAGE) {
+            breakBoat(true);
+        }
+        return true;
+    }
+
+    protected boolean isCreativeAttacker(DamageContainer damage) {
+        return damage.getAttacker() instanceof EntityPlayer player && player.getGameMode() == GameMode.CREATIVE;
+    }
+
+    protected void breakBoat(boolean dropItem) {
+        boat.ejectPassengers();
+        if (dropItem && thisEntity.getWorld().getWorldData().<Boolean>getGameRuleValue(GameRule.DO_ENTITY_DROPS)) {
+            thisEntity.getDimension().dropItem(BoatItemHelper.createItem(boat.getBoatVariant()), thisEntity.getLocation());
+        }
+        thisEntity.remove();
+    }
+
+    public float getAccumulatedDamage() {
+        return accumulatedDamage;
+    }
+
+    @Override
+    public boolean hasFallDamage() {
+        return false;
+    }
+
+    @Override
+    public boolean hasDrowningDamage() {
+        return false;
+    }
+
+    @Override
+    public boolean canBreathe() {
+        return true;
+    }
+
+    @Override
+    protected boolean hasDeadTimer() {
+        return false;
+    }
+}

--- a/server/src/main/java/org/allaymc/server/entity/component/vehicle/EntityBoatPhysicsComponentImpl.java
+++ b/server/src/main/java/org/allaymc/server/entity/component/vehicle/EntityBoatPhysicsComponentImpl.java
@@ -1,0 +1,60 @@
+package org.allaymc.server.entity.component.vehicle;
+
+import org.allaymc.api.entity.component.EntityBoatBaseComponent;
+import org.allaymc.server.component.annotation.Dependency;
+import org.allaymc.server.entity.component.EntityPhysicsComponentImpl;
+import org.joml.Vector3d;
+
+/**
+ * Server-authoritative boat movement and buoyancy.
+ */
+public class EntityBoatPhysicsComponentImpl extends EntityPhysicsComponentImpl {
+    @Dependency
+    protected EntityBoatBaseComponent boatComponent;
+
+    @Override
+    public double getGravity() {
+        return 0.04;
+    }
+
+    @Override
+    public double getDragFactorOnGround() {
+        return 0.5;
+    }
+
+    @Override
+    public double getDragFactorInAir() {
+        return 0.01;
+    }
+
+    @Override
+    public Vector3d updateMotion(LiquidState liquidState) {
+        if (liquidState.inWater()) {
+            return new Vector3d(
+                    motion.x() * 0.9,
+                    Math.clamp((motion.y() - getGravity() + 0.08) * 0.9, -0.1, 0.1),
+                    motion.z() * 0.9
+            );
+        }
+        if (liquidState.inLava()) {
+            return new Vector3d(motion.x() * 0.5, (motion.y() - getGravity()) * 0.5, motion.z() * 0.5);
+        }
+        return super.updateMotion(liquidState);
+    }
+
+    @Override
+    public void afterApplyMotion() {
+        super.afterApplyMotion();
+        boatComponent.updatePassengerPositions();
+    }
+
+    @Override
+    public boolean hasGravity() {
+        return true;
+    }
+
+    @Override
+    public double getStepHeight() {
+        return 0.0;
+    }
+}

--- a/server/src/main/java/org/allaymc/server/entity/component/vehicle/EntityBoatRideableComponentImpl.java
+++ b/server/src/main/java/org/allaymc/server/entity/component/vehicle/EntityBoatRideableComponentImpl.java
@@ -1,0 +1,134 @@
+package org.allaymc.server.entity.component.vehicle;
+
+import org.allaymc.api.entity.component.EntityRideableComponent;
+import org.allaymc.api.entity.data.EntityLinkType;
+import org.allaymc.api.entity.interfaces.EntityBoat;
+import org.allaymc.api.entity.interfaces.EntityPlayer;
+import org.allaymc.api.eventbus.EventHandler;
+import org.allaymc.api.math.location.Location3d;
+import org.allaymc.api.player.GameMode;
+import org.allaymc.api.utils.identifier.Identifier;
+import org.allaymc.server.component.annotation.ComponentObject;
+import org.allaymc.server.entity.component.event.CEntityBeforeTeleportEvent;
+import org.allaymc.server.entity.component.event.CEntityDieEvent;
+import org.joml.primitives.AABBd;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+
+/**
+ * Player passenger handling for ordinary boats and bamboo rafts.
+ */
+public class EntityBoatRideableComponentImpl implements EntityRideableComponent {
+
+    @Identifier.Component
+    public static final Identifier IDENTIFIER = new Identifier("minecraft:entity_rideable_component");
+
+    @ComponentObject
+    protected EntityBoat boat;
+
+    protected final List<EntityPlayer> passengers = new ArrayList<>(2);
+
+    @Override
+    public int getPassengerCapacity() {
+        return 2;
+    }
+
+    @Override
+    public List<EntityPlayer> getPassengers() {
+        return List.copyOf(passengers);
+    }
+
+    @Override
+    public EntityPlayer getControllingPassenger() {
+        return passengers.isEmpty() ? null : passengers.getFirst();
+    }
+
+    @Override
+    public boolean addPassenger(EntityPlayer passenger) {
+        if (passenger == null || passenger.getGameMode() == GameMode.SPECTATOR ||
+            passenger.getDimension() != boat.getDimension() || passenger.isRiding() ||
+            passengers.contains(passenger) || passengers.size() >= getPassengerCapacity()) {
+            return false;
+        }
+
+        passengers.add(passenger);
+        passenger.setVehicle(boat);
+        broadcastLink(passenger, passengers.size() == 1 ? EntityLinkType.RIDER : EntityLinkType.PASSENGER);
+        boat.broadcastState();
+        boat.updatePassengerPositions();
+        return true;
+    }
+
+    @Override
+    public boolean removePassenger(EntityPlayer passenger) {
+        var index = passengers.indexOf(passenger);
+        if (index < 0) {
+            return false;
+        }
+
+        boat.setPaddleInput(getControllingPassenger(), null, false, false);
+        broadcastLink(passenger, EntityLinkType.REMOVE);
+        passengers.remove(index);
+        passenger.setVehicle(null);
+        movePassengerToDismountPosition(passenger);
+
+        if (index == 0 && !passengers.isEmpty()) {
+            var promoted = passengers.getFirst();
+            broadcastLink(promoted, EntityLinkType.REMOVE);
+            broadcastLink(promoted, EntityLinkType.RIDER);
+        }
+
+        boat.broadcastState();
+        boat.updatePassengerPositions();
+        return true;
+    }
+
+    @Override
+    public void ejectPassengers() {
+        for (var passenger : List.copyOf(passengers)) {
+            removePassenger(passenger);
+        }
+    }
+
+    protected void movePassengerToDismountPosition(EntityPlayer passenger) {
+        var yaw = Math.toRadians(boat.getLocation().yaw());
+        var sideX = Math.cos(yaw) * 1.5;
+        var sideZ = Math.sin(yaw) * 1.5;
+        var candidates = new double[][]{
+                {boat.getLocation().x() + sideX, boat.getLocation().y(), boat.getLocation().z() + sideZ},
+                {boat.getLocation().x() - sideX, boat.getLocation().y(), boat.getLocation().z() - sideZ},
+                {boat.getLocation().x() + sideZ, boat.getLocation().y(), boat.getLocation().z() - sideX},
+                {boat.getLocation().x() - sideZ, boat.getLocation().y(), boat.getLocation().z() + sideX}
+        };
+        for (var candidate : candidates) {
+            var aabb = passenger.getAABB().translate(candidate[0], candidate[1], candidate[2], new AABBd());
+            if (boat.getDimension().getCollidingBlockStates(aabb) == null && !aabb.intersectsAABB(boat.getOffsetAABB())) {
+                passenger.trySetLocation(new Location3d(candidate[0], candidate[1], candidate[2],
+                        passenger.getLocation().pitch(), passenger.getLocation().yaw(), boat.getDimension()));
+                return;
+            }
+        }
+        passenger.trySetLocation(new Location3d(boat.getLocation().x(), boat.getLocation().y() + 0.6, boat.getLocation().z(),
+                passenger.getLocation().pitch(), passenger.getLocation().yaw(), boat.getDimension()));
+    }
+
+    protected void broadcastLink(EntityPlayer passenger, EntityLinkType linkType) {
+        var viewers = new LinkedHashSet<>(boat.getViewers());
+        if (passenger.getController() != null) {
+            viewers.add(passenger.getController());
+        }
+        viewers.forEach(viewer -> viewer.viewEntityLink(boat, passenger, linkType));
+    }
+
+    @EventHandler
+    protected void onBeforeTeleport(CEntityBeforeTeleportEvent event) {
+        ejectPassengers();
+    }
+
+    @EventHandler
+    protected void onDie(CEntityDieEvent event) {
+        ejectPassengers();
+    }
+}

--- a/server/src/main/java/org/allaymc/server/entity/impl/EntityBoatImpl.java
+++ b/server/src/main/java/org/allaymc/server/entity/impl/EntityBoatImpl.java
@@ -1,13 +1,26 @@
 package org.allaymc.server.entity.impl;
 
+import lombok.Getter;
+import lombok.experimental.Delegate;
 import org.allaymc.api.component.Component;
 import org.allaymc.api.entity.EntityInitInfo;
+import org.allaymc.api.entity.component.EntityBoatBaseComponent;
+import org.allaymc.api.entity.component.EntityLivingComponent;
+import org.allaymc.api.entity.component.EntityPhysicsComponent;
 import org.allaymc.api.entity.interfaces.EntityBoat;
 import org.allaymc.server.component.ComponentProvider;
 
 import java.util.List;
 
 public class EntityBoatImpl extends EntityImpl implements EntityBoat {
+    @Delegate
+    private EntityBoatBaseComponent boatBaseComponent;
+    @Delegate
+    private EntityLivingComponent livingComponent;
+    @Getter
+    @Delegate
+    private EntityPhysicsComponent physicsComponent;
+
     public EntityBoatImpl(EntityInitInfo initInfo,
                           List<ComponentProvider<? extends Component>> componentProviders) {
         super(initInfo, componentProviders);

--- a/server/src/main/java/org/allaymc/server/entity/impl/EntityBoatImpl.java
+++ b/server/src/main/java/org/allaymc/server/entity/impl/EntityBoatImpl.java
@@ -7,6 +7,7 @@ import org.allaymc.api.entity.EntityInitInfo;
 import org.allaymc.api.entity.component.EntityBoatBaseComponent;
 import org.allaymc.api.entity.component.EntityLivingComponent;
 import org.allaymc.api.entity.component.EntityPhysicsComponent;
+import org.allaymc.api.entity.component.EntityRideableComponent;
 import org.allaymc.api.entity.interfaces.EntityBoat;
 import org.allaymc.server.component.ComponentProvider;
 
@@ -20,6 +21,8 @@ public class EntityBoatImpl extends EntityImpl implements EntityBoat {
     @Getter
     @Delegate
     private EntityPhysicsComponent physicsComponent;
+    @Delegate
+    private EntityRideableComponent rideableComponent;
 
     public EntityBoatImpl(EntityInitInfo initInfo,
                           List<ComponentProvider<? extends Component>> componentProviders) {

--- a/server/src/main/java/org/allaymc/server/entity/impl/EntityPlayerImpl.java
+++ b/server/src/main/java/org/allaymc/server/entity/impl/EntityPlayerImpl.java
@@ -8,6 +8,7 @@ import org.allaymc.api.entity.component.EntityContainerHolderComponent;
 import org.allaymc.api.entity.component.EntityLivingComponent;
 import org.allaymc.api.entity.component.EntityPhysicsComponent;
 import org.allaymc.api.entity.component.EntityPlayerBaseComponent;
+import org.allaymc.api.entity.component.EntityRiderComponent;
 import org.allaymc.api.entity.component.EntitySleepableComponent;
 import org.allaymc.api.entity.interfaces.EntityPlayer;
 import org.allaymc.server.component.ComponentProvider;
@@ -28,6 +29,8 @@ public class EntityPlayerImpl extends EntityImpl implements EntityPlayer {
     private EntityPhysicsComponent physicsComponent;
     @Delegate
     private EntitySleepableComponent sleepableComponent;
+    @Delegate
+    private EntityRiderComponent riderComponent;
 
     public EntityPlayerImpl(EntityInitInfo initInfo, List<ComponentProvider<? extends Component>> componentProviders) {
         super(initInfo, componentProviders);

--- a/server/src/main/java/org/allaymc/server/entity/type/EntityTypeInitializer.java
+++ b/server/src/main/java/org/allaymc/server/entity/type/EntityTypeInitializer.java
@@ -43,6 +43,9 @@ import org.allaymc.server.entity.component.player.EntityPlayerContainerHolderCom
 import org.allaymc.server.entity.component.player.EntityPlayerLivingComponentImpl;
 import org.allaymc.server.entity.component.player.EntityPlayerPhysicsComponentImpl;
 import org.allaymc.server.entity.component.projectile.*;
+import org.allaymc.server.entity.component.vehicle.EntityBoatBaseComponentImpl;
+import org.allaymc.server.entity.component.vehicle.EntityBoatLivingComponentImpl;
+import org.allaymc.server.entity.component.vehicle.EntityBoatPhysicsComponentImpl;
 import org.allaymc.server.entity.data.EntityId;
 import org.allaymc.server.entity.impl.*;
 import org.joml.Vector3i;
@@ -58,6 +61,16 @@ import static org.allaymc.server.entity.ai.evaluator.LogicHelper.any;
 @SuppressWarnings("unused")
 @UtilityClass
 public final class EntityTypeInitializer {
+    public static void initBoat() {
+        EntityTypes.BOAT = AllayEntityType
+                .builder(EntityBoatImpl.class)
+                .vanillaEntity(EntityId.BOAT)
+                .addComponent(EntityBoatBaseComponentImpl::new, EntityBoatBaseComponentImpl.class)
+                .addComponent(EntityBoatLivingComponentImpl::new, EntityBoatLivingComponentImpl.class)
+                .addComponent(EntityBoatPhysicsComponentImpl::new, EntityBoatPhysicsComponentImpl.class)
+                .build();
+    }
+
     public static void initFallingBlock() {
         EntityTypes.FALLING_BLOCK = AllayEntityType
                 .builder(EntityFallingBlockImpl.class)

--- a/server/src/main/java/org/allaymc/server/entity/type/EntityTypeInitializer.java
+++ b/server/src/main/java/org/allaymc/server/entity/type/EntityTypeInitializer.java
@@ -46,6 +46,7 @@ import org.allaymc.server.entity.component.projectile.*;
 import org.allaymc.server.entity.component.vehicle.EntityBoatBaseComponentImpl;
 import org.allaymc.server.entity.component.vehicle.EntityBoatLivingComponentImpl;
 import org.allaymc.server.entity.component.vehicle.EntityBoatPhysicsComponentImpl;
+import org.allaymc.server.entity.component.vehicle.EntityBoatRideableComponentImpl;
 import org.allaymc.server.entity.data.EntityId;
 import org.allaymc.server.entity.impl.*;
 import org.joml.Vector3i;
@@ -68,6 +69,7 @@ public final class EntityTypeInitializer {
                 .addComponent(EntityBoatBaseComponentImpl::new, EntityBoatBaseComponentImpl.class)
                 .addComponent(EntityBoatLivingComponentImpl::new, EntityBoatLivingComponentImpl.class)
                 .addComponent(EntityBoatPhysicsComponentImpl::new, EntityBoatPhysicsComponentImpl.class)
+                .addComponent(EntityBoatRideableComponentImpl::new, EntityBoatRideableComponentImpl.class)
                 .build();
     }
 
@@ -191,6 +193,7 @@ public final class EntityTypeInitializer {
                 .addComponent(EntityPlayerContainerHolderComponentImpl::new, EntityPlayerContainerHolderComponentImpl.class)
                 .addComponent(EntityPlayerLivingComponentImpl::new, EntityPlayerLivingComponentImpl.class)
                 .addComponent(EntityPlayerPhysicsComponentImpl::new, EntityPlayerPhysicsComponentImpl.class)
+                .addComponent(EntityRiderComponentImpl::new, EntityRiderComponentImpl.class)
                 .addComponent(EntitySleepableComponentImpl::new, EntitySleepableComponentImpl.class)
                 .build();
     }

--- a/server/src/main/java/org/allaymc/server/item/component/ItemBoatBaseComponentImpl.java
+++ b/server/src/main/java/org/allaymc/server/item/component/ItemBoatBaseComponentImpl.java
@@ -1,0 +1,67 @@
+package org.allaymc.server.item.component;
+
+import org.allaymc.api.block.data.BlockTags;
+import org.allaymc.api.block.dto.PlayerInteractInfo;
+import org.allaymc.api.entity.EntityInitInfo;
+import org.allaymc.api.entity.data.BoatVariant;
+import org.allaymc.api.entity.type.EntityTypes;
+import org.allaymc.api.item.ItemStackInitInfo;
+import org.allaymc.api.player.GameMode;
+import org.allaymc.api.world.Dimension;
+import org.joml.Vector3ic;
+import org.joml.primitives.AABBd;
+
+import java.util.Objects;
+
+/**
+ * Places a configured ordinary boat variant.
+ */
+public class ItemBoatBaseComponentImpl extends ItemBaseComponentImpl {
+    protected final BoatVariant variant;
+
+    public ItemBoatBaseComponentImpl(ItemStackInitInfo initInfo, BoatVariant variant) {
+        super(initInfo);
+        this.variant = Objects.requireNonNull(variant, "variant");
+    }
+
+    @Override
+    public boolean useItemOnBlock(Dimension dimension, Vector3ic placeBlockPos, PlayerInteractInfo interactInfo) {
+        if (super.useItemOnBlock(dimension, placeBlockPos, interactInfo)) {
+            return true;
+        }
+        if (interactInfo == null) {
+            return false;
+        }
+
+        var player = interactInfo.player();
+        if (player.getGameMode() == GameMode.ADVENTURE || player.getGameMode() == GameMode.SPECTATOR) {
+            return false;
+        }
+        if (!dimension.getBlockState(placeBlockPos).getBlockType().hasBlockTag(BlockTags.REPLACEABLE)) {
+            return false;
+        }
+
+        var x = placeBlockPos.x() + 0.5;
+        var y = (double) placeBlockPos.y();
+        var z = placeBlockPos.z() + 0.5;
+        var boatAABB = new AABBd(x - 0.7, y, z - 0.7, x + 0.7, y + 0.455, z + 0.7);
+        if (dimension.getCollidingBlockStates(boatAABB) != null ||
+            !dimension.getEntityManager().getPhysicsService().computeCollidingEntities(boatAABB).isEmpty()) {
+            return false;
+        }
+
+        var boat = EntityTypes.BOAT.createEntity(EntityInitInfo.builder()
+                .dimension(dimension)
+                .pos(x, y, z)
+                .rot(player.getLocation().yaw(), 0)
+                .build());
+        boat.setBoatVariant(variant);
+        var customName = thisItemStack.getCustomName();
+        if (customName != null && !customName.isEmpty()) {
+            boat.setNameTag(customName);
+        }
+        dimension.getEntityManager().addEntity(boat);
+        player.tryConsumeItemInHand();
+        return true;
+    }
+}

--- a/server/src/main/java/org/allaymc/server/item/type/ItemTypeInitializer.java
+++ b/server/src/main/java/org/allaymc/server/item/type/ItemTypeInitializer.java
@@ -7,6 +7,7 @@ import org.allaymc.api.entity.interfaces.EntityPlayer;
 import org.allaymc.api.entity.interfaces.EntityProjectile;
 import org.allaymc.api.entity.interfaces.EntitySplashPotion;
 import org.allaymc.api.entity.property.enums.ClimateVariant;
+import org.allaymc.api.entity.data.BoatVariant;
 import org.allaymc.api.item.ItemStack;
 import org.allaymc.api.item.data.ArmorType;
 import org.allaymc.api.item.data.DiscType;
@@ -46,6 +47,32 @@ import java.util.function.Supplier;
 @SuppressWarnings("unused")
 @UtilityClass
 public final class ItemTypeInitializer {
+    public static void initBoats() {
+        ItemTypes.BOAT = buildBoat(ItemId.BOAT, BoatVariant.OAK);
+        ItemTypes.OAK_BOAT = buildBoat(ItemId.OAK_BOAT, BoatVariant.OAK);
+        ItemTypes.SPRUCE_BOAT = buildBoat(ItemId.SPRUCE_BOAT, BoatVariant.SPRUCE);
+        ItemTypes.BIRCH_BOAT = buildBoat(ItemId.BIRCH_BOAT, BoatVariant.BIRCH);
+        ItemTypes.JUNGLE_BOAT = buildBoat(ItemId.JUNGLE_BOAT, BoatVariant.JUNGLE);
+        ItemTypes.ACACIA_BOAT = buildBoat(ItemId.ACACIA_BOAT, BoatVariant.ACACIA);
+        ItemTypes.DARK_OAK_BOAT = buildBoat(ItemId.DARK_OAK_BOAT, BoatVariant.DARK_OAK);
+        ItemTypes.MANGROVE_BOAT = buildBoat(ItemId.MANGROVE_BOAT, BoatVariant.MANGROVE);
+        ItemTypes.CHERRY_BOAT = buildBoat(ItemId.CHERRY_BOAT, BoatVariant.CHERRY);
+        ItemTypes.PALE_OAK_BOAT = buildBoat(ItemId.PALE_OAK_BOAT, BoatVariant.PALE_OAK);
+        ItemTypes.BAMBOO_RAFT = AllayItemType
+                .builder(ItemBambooRaftStackImpl.class)
+                .vanillaItem(ItemId.BAMBOO_RAFT)
+                .addComponent(info -> new ItemBoatBaseComponentImpl(info, BoatVariant.BAMBOO), ItemBoatBaseComponentImpl.class)
+                .build();
+    }
+
+    private static ItemType<ItemBoatStack> buildBoat(ItemId itemId, BoatVariant variant) {
+        return AllayItemType
+                .builder(ItemBoatStackImpl.class)
+                .vanillaItem(itemId)
+                .addComponent(info -> new ItemBoatBaseComponentImpl(info, variant), ItemBoatBaseComponentImpl.class)
+                .build();
+    }
+
     public static void initBanner() {
         ItemTypes.BANNER = AllayItemType
                 .builder(ItemBannerStackImpl.class)

--- a/server/src/main/java/org/allaymc/server/network/processor/ingame/InteractPacketProcessor.java
+++ b/server/src/main/java/org/allaymc/server/network/processor/ingame/InteractPacketProcessor.java
@@ -1,6 +1,7 @@
 package org.allaymc.server.network.processor.ingame;
 
 import org.allaymc.api.container.ContainerTypes;
+import org.allaymc.api.entity.component.EntityRideableComponent;
 import org.allaymc.api.player.Player;
 import org.allaymc.server.network.processor.PacketProcessor;
 import org.cloudburstmc.protocol.bedrock.packet.BedrockPacketType;
@@ -12,8 +13,12 @@ import org.cloudburstmc.protocol.bedrock.packet.InteractPacket;
 public class InteractPacketProcessor extends PacketProcessor<InteractPacket> {
     @Override
     public void handleSync(Player player, InteractPacket packet, long receiveTime) {
+        var entity = player.getControlledEntity();
         if (packet.getAction() == InteractPacket.Action.OPEN_INVENTORY) {
-            player.getControlledEntity().getContainer(ContainerTypes.INVENTORY).addViewer(player);
+            entity.getContainer(ContainerTypes.INVENTORY).addViewer(player);
+        } else if (packet.getAction() == InteractPacket.Action.LEAVE_VEHICLE &&
+                   entity.getVehicle() instanceof EntityRideableComponent rideableComponent) {
+            rideableComponent.removePassenger(entity);
         }
     }
 

--- a/server/src/main/java/org/allaymc/server/network/processor/ingame/PlayerAuthInputPacketProcessor.java
+++ b/server/src/main/java/org/allaymc/server/network/processor/ingame/PlayerAuthInputPacketProcessor.java
@@ -9,6 +9,7 @@ import org.allaymc.api.block.dto.Block;
 import org.allaymc.api.block.type.BlockState;
 import org.allaymc.api.block.type.BlockTypes;
 import org.allaymc.api.eventbus.event.block.BlockBreakEvent;
+import org.allaymc.api.entity.interfaces.EntityBoat;
 import org.allaymc.api.eventbus.event.server.PlayerControlModeUpdateEvent;
 import org.allaymc.api.eventbus.event.player.PlayerJumpEvent;
 import org.allaymc.api.eventbus.event.player.PlayerPunchAirEvent;
@@ -396,6 +397,8 @@ public class PlayerAuthInputPacketProcessor extends PacketProcessor<PlayerAuthIn
 
         updatePlayerInputState((AllayPlayer) player, packet);
 
+        var ridingVehicle = handleVehicleInput(player, packet);
+
         var baseComponent = ((EntityPlayerBaseComponentImpl) ((EntityPlayerImpl) player.getControlledEntity()).getBaseComponent());
         if (baseComponent.getExpectedTeleportPos() != null) {
             var clientPos = NetworkHelper.fromNetwork(packet.getPosition().sub(0, PLAYER_NETWORK_OFFSET, 0));
@@ -414,7 +417,7 @@ public class PlayerAuthInputPacketProcessor extends PacketProcessor<PlayerAuthIn
             return PacketSignal.HANDLED;
         }
 
-        if (isLocationChanged(player, packet.getPosition(), packet.getRotation())) {
+        if (!ridingVehicle && isLocationChanged(player, packet.getPosition(), packet.getRotation())) {
             // The pos which the client sends to the server is higher than the actual coordinates (one base offset)
             handleMovement(player, packet.getPosition().sub(0, PLAYER_NETWORK_OFFSET, 0), packet.getRotation());
         }
@@ -448,6 +451,39 @@ public class PlayerAuthInputPacketProcessor extends PacketProcessor<PlayerAuthIn
             }
         }
         return PacketSignal.UNHANDLED;
+    }
+
+    protected boolean handleVehicleInput(Player player, PlayerAuthInputPacket packet) {
+        var entity = player.getControlledEntity();
+        if (!(entity.getVehicle() instanceof EntityBoat boat)) {
+            return false;
+        }
+
+        // Ignore spoofed vehicle input, but continue suppressing standalone player movement while mounted.
+        if (packet.getPredictedVehicle() != 0 && packet.getPredictedVehicle() != boat.getRuntimeId()) {
+            return true;
+        }
+        if (boat.getControllingPassenger() != entity) {
+            return true;
+        }
+
+        var input = packet.getRawMoveVector();
+        if (input == null || input.lengthSquared() == 0) {
+            input = packet.getAnalogMoveVector();
+        }
+        if (input == null || input.lengthSquared() == 0) {
+            input = packet.getMotion();
+        }
+        var movement = input == null || !Float.isFinite(input.getX()) || !Float.isFinite(input.getY())
+                ? new org.joml.Vector2f()
+                : new org.joml.Vector2f(input.getX(), input.getY());
+        boat.setPaddleInput(
+                entity,
+                movement,
+                packet.getInputData().contains(PlayerAuthInputData.PADDLE_LEFT),
+                packet.getInputData().contains(PlayerAuthInputData.PADDLE_RIGHT)
+        );
+        return true;
     }
 
     protected boolean validateClientLocation(Player player, Vector3f pos, Vector3f rot) {

--- a/server/src/main/java/org/allaymc/server/player/AllayPlayer.java
+++ b/server/src/main/java/org/allaymc/server/player/AllayPlayer.java
@@ -36,6 +36,7 @@ import org.allaymc.api.entity.Entity;
 import org.allaymc.api.entity.action.*;
 import org.allaymc.api.entity.component.*;
 import org.allaymc.api.entity.data.EntityAnimation;
+import org.allaymc.api.entity.data.EntityLinkType;
 import org.allaymc.api.entity.effect.EffectInstance;
 import org.allaymc.api.entity.interfaces.*;
 import org.allaymc.api.entity.type.EntityTypes;
@@ -129,6 +130,7 @@ import org.cloudburstmc.protocol.bedrock.data.entity.EntityDataMap;
 import org.cloudburstmc.protocol.bedrock.data.entity.EntityDataTypes;
 import org.cloudburstmc.protocol.bedrock.data.entity.EntityEventType;
 import org.cloudburstmc.protocol.bedrock.data.entity.EntityFlag;
+import org.cloudburstmc.protocol.bedrock.data.entity.EntityLinkData;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ContainerSlotType;
 import org.cloudburstmc.protocol.bedrock.data.inventory.FullContainerName;
 import org.cloudburstmc.protocol.bedrock.definition.SimpleDefinitionRegistry;
@@ -596,6 +598,21 @@ public class AllayPlayer implements Player {
         sendPacket(packet);
     }
 
+    @Override
+    public void viewEntityLink(Entity vehicle, Entity passenger, EntityLinkType linkType) {
+        var packet = new SetEntityLinkPacket();
+        var networkType = switch (linkType) {
+            case RIDER -> EntityLinkData.Type.RIDER;
+            case PASSENGER -> EntityLinkData.Type.PASSENGER;
+            case REMOVE -> EntityLinkData.Type.REMOVE;
+        };
+        packet.setEntityLink(new EntityLinkData(
+                vehicle.getUniqueId().getLeastSignificantBits(), passenger.getUniqueId().getLeastSignificantBits(), networkType,
+                true, true, 0
+        ));
+        sendPacket(packet);
+    }
+
     protected EntityDataMap parseMetadata(Entity entity) {
         var map = new EntityDataMap();
         addGenericMetadata(entity, map);
@@ -783,6 +800,18 @@ public class AllayPlayer implements Player {
             }
             case EntitySheep sheep -> {
                 map.setFlag(EntityFlag.SHEARED, sheep.isSheared());
+            }
+            case EntityBoat boat -> {
+                map.put(EntityDataTypes.VARIANT, boat.getBoatVariant().getNetworkId());
+                map.put(EntityDataTypes.ROW_TIME_LEFT, boat.getRowTimeLeft());
+                map.put(EntityDataTypes.ROW_TIME_RIGHT, boat.getRowTimeRight());
+                if (boat.getLastDamage() != null) {
+                    var interval = boat.getTick() - boat.getLastDamageTime();
+                    if (interval <= 10) {
+                        map.put(EntityDataTypes.HURT_TICKS, (int) interval);
+                    }
+                }
+                map.put(EntityDataTypes.CONTROLLING_RIDER_SEAT_INDEX, (byte) 0);
             }
             default -> {
             }

--- a/server/src/main/java/org/allaymc/server/world/manager/AllayEntityManager.java
+++ b/server/src/main/java/org/allaymc/server/world/manager/AllayEntityManager.java
@@ -7,6 +7,7 @@ import org.allaymc.api.entity.Entity;
 import org.allaymc.api.entity.EntityState;
 import org.allaymc.api.entity.component.EntityParallelTickComponent;
 import org.allaymc.api.entity.component.EntitySleepableComponent;
+import org.allaymc.api.entity.component.EntityRideableComponent;
 import org.allaymc.api.entity.interfaces.EntityPlayer;
 import org.allaymc.api.eventbus.event.entity.EntityDespawnEvent;
 import org.allaymc.api.eventbus.event.entity.EntitySpawnEvent;
@@ -266,6 +267,14 @@ public class AllayEntityManager implements EntityManager {
 
     protected void removeEntityImmediately(Entity entity) {
         new EntityDespawnEvent(entity).call();
+
+        if (entity instanceof EntityRideableComponent rideableComponent) {
+            rideableComponent.ejectPassengers();
+        }
+        if (entity instanceof EntityPlayer player &&
+            player.getVehicle() instanceof EntityRideableComponent rideableComponent) {
+            rideableComponent.removePassenger(player);
+        }
 
         // Wake up the entity if they are sleeping, so the bed's occupied state is cleared
         if (entity instanceof EntitySleepableComponent sleepableComponent && sleepableComponent.isSleeping()) {

--- a/server/src/main/java/org/allaymc/server/world/physics/AllayEntityPhysicsEngine.java
+++ b/server/src/main/java/org/allaymc/server/world/physics/AllayEntityPhysicsEngine.java
@@ -9,6 +9,7 @@ import org.allaymc.api.block.type.BlockState;
 import org.allaymc.api.entity.Entity;
 import org.allaymc.api.entity.component.EntityPhysicsComponent;
 import org.allaymc.api.entity.component.EntityPhysicsComponent.LiquidState;
+import org.allaymc.api.entity.component.EntityRideableComponent;
 import org.allaymc.api.entity.interfaces.EntityLiving;
 import org.allaymc.api.entity.interfaces.EntityPlayer;
 import org.allaymc.api.eventbus.event.player.PlayerMoveEvent;
@@ -251,7 +252,12 @@ public class AllayEntityPhysicsEngine implements EntityPhysicsEngine {
 
         var location = entity.getLocation();
         var pushSpeedReduction = ((EntityPhysicsComponent) entity).getPushSpeedReduction();
+        var passengers = entity instanceof EntityRideableComponent rideable ? rideable.getPassengers() : Collections.emptyList();
         for (var other : collidedEntities) {
+            if (passengers.contains(other)) {
+                continue;
+            }
+
             // https://github.com/lovexyn0827/Discovering-Minecraft/blob/master/Minecraft%E5%AE%9E%E4%BD%93%E8%BF%90%E5%8A%A8%E7%A0%94%E7%A9%B6%E4%B8%8E%E5%BA%94%E7%94%A8/5-Chapter-5.md
             var ol = other.getLocation();
             var direction = MathUtils.normalizeIfNotZero(new Vector3d(entity.getLocation()).sub(other.getLocation(), new Vector3d()));

--- a/server/src/test/java/org/allaymc/api/entity/data/BoatVariantTest.java
+++ b/server/src/test/java/org/allaymc/api/entity/data/BoatVariantTest.java
@@ -1,0 +1,17 @@
+package org.allaymc.api.entity.data;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class BoatVariantTest {
+    @Test
+    void networkIdsMatchBedrockVariants() {
+        for (var variant : BoatVariant.values()) {
+            assertEquals(variant, BoatVariant.fromNetworkId(variant.getNetworkId()));
+        }
+        assertEquals(7, BoatVariant.BAMBOO.getNetworkId());
+        assertNull(BoatVariant.fromNetworkId(-1));
+    }
+}

--- a/server/src/test/java/org/allaymc/server/entity/BoatEntityTest.java
+++ b/server/src/test/java/org/allaymc/server/entity/BoatEntityTest.java
@@ -1,0 +1,160 @@
+package org.allaymc.server.entity;
+
+import org.allaymc.api.entity.EntityInitInfo;
+import org.allaymc.api.entity.Entity;
+import org.allaymc.api.block.dto.PlayerInteractInfo;
+import org.allaymc.api.block.type.BlockTypes;
+import org.allaymc.api.entity.component.EntityPhysicsComponent;
+import org.allaymc.api.entity.data.BoatVariant;
+import org.allaymc.api.entity.interfaces.EntityBoat;
+import org.allaymc.api.entity.interfaces.EntityPlayer;
+import org.allaymc.api.entity.type.EntityTypes;
+import org.allaymc.api.item.type.ItemTypes;
+import org.allaymc.api.math.location.Location3d;
+import org.allaymc.api.player.GameMode;
+import org.allaymc.api.world.Dimension;
+import org.allaymc.api.world.manager.EntityManager;
+import org.allaymc.api.world.physics.EntityPhysicsEngine;
+import org.allaymc.server.entity.component.EntityBaseComponentImpl;
+import org.allaymc.server.entity.impl.EntityBoatImpl;
+import org.allaymc.testutils.AllayTestExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.joml.Vector2f;
+import org.joml.Vector3d;
+import org.joml.Vector3i;
+import org.joml.primitives.AABBd;
+import org.joml.primitives.AABBdc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
+
+@ExtendWith(AllayTestExtension.class)
+class BoatEntityTest {
+    private final Dimension dimension = Mockito.mock(Dimension.class);
+
+    @Test
+    void boatTypeHasFunctionalComponentsAndVanillaBounds() {
+        EntityBoat boat = EntityTypes.BOAT.createEntity(EntityInitInfo.builder()
+                .dimension(dimension)
+                .pos(1, 2, 3)
+                .build());
+
+        assertInstanceOf(EntityPhysicsComponent.class, boat);
+        assertEquals(2, boat.getPassengerCapacity());
+        assertEquals(1.4, boat.getBaseAABB().lengthX(), 0.00001);
+        assertEquals(0.455, boat.getBaseAABB().lengthY(), 0.00001);
+        assertEquals(BoatVariant.OAK, boat.getBoatVariant());
+    }
+
+    @Test
+    void variantSurvivesNbtRoundTrip() {
+        var boat = EntityTypes.BOAT.createEntity(EntityInitInfo.builder()
+                .dimension(dimension)
+                .pos(1, 2, 3)
+                .build());
+        boat.setBoatVariant(BoatVariant.BAMBOO);
+
+        var loaded = EntityTypes.BOAT.createEntity(EntityInitInfo.builder()
+                .dimension(dimension)
+                .nbt(boat.saveNBT())
+                .build());
+
+        assertEquals(BoatVariant.BAMBOO, loaded.getBoatVariant());
+    }
+
+    @Test
+    void allOrdinaryBoatItemsAreRegistered() {
+        assertNotNull(ItemTypes.BOAT);
+        assertNotNull(ItemTypes.OAK_BOAT);
+        assertNotNull(ItemTypes.SPRUCE_BOAT);
+        assertNotNull(ItemTypes.BIRCH_BOAT);
+        assertNotNull(ItemTypes.JUNGLE_BOAT);
+        assertNotNull(ItemTypes.ACACIA_BOAT);
+        assertNotNull(ItemTypes.DARK_OAK_BOAT);
+        assertNotNull(ItemTypes.MANGROVE_BOAT);
+        assertNotNull(ItemTypes.BAMBOO_RAFT);
+        assertNotNull(ItemTypes.CHERRY_BOAT);
+        assertNotNull(ItemTypes.PALE_OAK_BOAT);
+    }
+
+    @Test
+    void passengersFillTwoSeatsAndSecondPassengerIsPromoted() {
+        var boat = createBoat();
+        var first = mockPassenger();
+        var second = mockPassenger();
+        var third = mockPassenger();
+
+        assertTrue(boat.addPassenger(first));
+        assertTrue(boat.addPassenger(second));
+        assertFalse(boat.addPassenger(third));
+        assertSame(first, boat.getControllingPassenger());
+        verify(first).setVehicle(boat);
+        verify(second).setVehicle(boat);
+
+        assertTrue(boat.removePassenger(first));
+        assertSame(second, boat.getControllingPassenger());
+        verify(first).setVehicle(null);
+    }
+
+    @Test
+    void controllerInputAcceleratesBoatAndWaterProvidesBuoyancy() {
+        var boat = createBoat();
+        var controller = mockPassenger();
+        assertTrue(boat.addPassenger(controller));
+
+        boat.setPaddleInput(controller, new Vector2f(0, 1), true, true);
+        ((EntityBaseComponentImpl) ((EntityBoatImpl) boat).getBaseComponent()).tick(1);
+        assertTrue(boat.getMotion().lengthSquared() > 0);
+
+        boat.setMotion(new Vector3d(0, -0.05, 0));
+        var floatingMotion = boat.updateMotion(new EntityPhysicsComponent.LiquidState(true, false));
+        assertTrue(floatingMotion.y() > -0.05);
+    }
+
+    @Test
+    void boatItemPlacesConfiguredEntity() {
+        var manager = Mockito.mock(EntityManager.class);
+        var physics = Mockito.mock(EntityPhysicsEngine.class);
+        var player = mockPassenger();
+        var pos = new Vector3i(4, 5, 6);
+        when(dimension.getBlockState(pos)).thenReturn(BlockTypes.AIR.getDefaultState());
+        when(dimension.getEntityManager()).thenReturn(manager);
+        when(manager.getPhysicsService()).thenReturn(physics);
+        when(physics.computeCollidingEntities(any(AABBdc.class))).thenReturn(java.util.List.of());
+
+        var item = ItemTypes.MANGROVE_BOAT.createItemStack();
+        var used = item.useItemOnBlock(dimension, pos, new PlayerInteractInfo(player, pos, new org.joml.Vector3f(), org.allaymc.api.block.data.BlockFace.UP));
+
+        assertTrue(used);
+        var entityCaptor = org.mockito.ArgumentCaptor.forClass(Entity.class);
+        verify(manager).addEntity(entityCaptor.capture());
+        assertEquals(BoatVariant.MANGROVE, ((EntityBoat) entityCaptor.getValue()).getBoatVariant());
+        verify(player).tryConsumeItemInHand();
+    }
+
+    private EntityBoat createBoat() {
+        return EntityTypes.BOAT.createEntity(EntityInitInfo.builder()
+                .dimension(dimension)
+                .pos(1, 2, 3)
+                .build());
+    }
+
+    private EntityPlayer mockPassenger() {
+        var player = Mockito.mock(EntityPlayer.class);
+        when(player.getGameMode()).thenReturn(GameMode.SURVIVAL);
+        when(player.getDimension()).thenReturn(dimension);
+        when(player.getLocation()).thenReturn(new Location3d(1, 2, 3, dimension));
+        when(player.getAABB()).thenReturn(new AABBd(-0.3, 0, -0.3, 0.3, 1.8, 0.3));
+        when(player.trySetLocation(Mockito.any())).thenReturn(true);
+        return player;
+    }
+}

--- a/server/src/test/java/org/allaymc/server/entity/BoatEntityTest.java
+++ b/server/src/test/java/org/allaymc/server/entity/BoatEntityTest.java
@@ -5,6 +5,10 @@ import org.allaymc.api.entity.Entity;
 import org.allaymc.api.block.dto.PlayerInteractInfo;
 import org.allaymc.api.block.type.BlockTypes;
 import org.allaymc.api.entity.component.EntityPhysicsComponent;
+import org.allaymc.api.entity.component.EntityBoatBaseComponent;
+import org.allaymc.api.entity.component.EntityPlayerBaseComponent;
+import org.allaymc.api.entity.component.EntityRideableComponent;
+import org.allaymc.api.entity.component.EntityRiderComponent;
 import org.allaymc.api.entity.data.BoatVariant;
 import org.allaymc.api.entity.interfaces.EntityBoat;
 import org.allaymc.api.entity.interfaces.EntityPlayer;
@@ -40,6 +44,14 @@ import static org.mockito.ArgumentMatchers.any;
 @ExtendWith(AllayTestExtension.class)
 class BoatEntityTest {
     private final Dimension dimension = Mockito.mock(Dimension.class);
+
+    @Test
+    void ridingContractsAreSeparateFromBaseComponents() {
+        assertFalse(EntityRideableComponent.class.isAssignableFrom(EntityBoatBaseComponent.class));
+        assertFalse(EntityRiderComponent.class.isAssignableFrom(EntityPlayerBaseComponent.class));
+        assertTrue(EntityRideableComponent.class.isAssignableFrom(EntityBoat.class));
+        assertTrue(EntityRiderComponent.class.isAssignableFrom(EntityPlayer.class));
+    }
 
     @Test
     void boatTypeHasFunctionalComponentsAndVanillaBounds() {

--- a/server/src/test/java/org/allaymc/server/world/physics/AllayEntityPhysicsEngineTest.java
+++ b/server/src/test/java/org/allaymc/server/world/physics/AllayEntityPhysicsEngineTest.java
@@ -1,0 +1,83 @@
+package org.allaymc.server.world.physics;
+
+import org.allaymc.api.entity.Entity;
+import org.allaymc.api.entity.interfaces.EntityBoat;
+import org.allaymc.api.entity.interfaces.EntityPlayer;
+import org.allaymc.api.math.location.Location3d;
+import org.allaymc.api.world.Dimension;
+import org.allaymc.testutils.AllayTestExtension;
+import org.joml.Vector3dc;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(AllayTestExtension.class)
+class AllayEntityPhysicsEngineTest {
+
+    @Test
+    void rideableCollisionMotionExcludesPassengers() {
+        var dimension = mock(Dimension.class);
+        var engine = new TestEntityPhysicsEngine(dimension);
+        var passenger = mock(EntityPlayer.class);
+        var boat = mockBoat(dimension, List.of(passenger));
+        when(passenger.hasEntityCollision()).thenReturn(true);
+        when(passenger.getLocation()).thenReturn(new Location3d(0, 0, 0, dimension));
+
+        engine.setCollisions(boat, passenger);
+        engine.applyEntityCollisionMotion(boat);
+
+        var motionCaptor = ArgumentCaptor.forClass(Vector3dc.class);
+        verify(boat).addMotion(motionCaptor.capture());
+        assertEquals(0, motionCaptor.getValue().lengthSquared(), 0.00001);
+    }
+
+    @Test
+    void rideableCollisionMotionStillIncludesOtherEntities() {
+        var dimension = mock(Dimension.class);
+        var engine = new TestEntityPhysicsEngine(dimension);
+        var boat = mockBoat(dimension, List.of());
+        var other = mock(Entity.class);
+        when(other.hasEntityCollision()).thenReturn(true);
+        when(other.getLocation()).thenReturn(new Location3d(0, 0, 0, dimension));
+
+        engine.setCollisions(boat, other);
+        engine.applyEntityCollisionMotion(boat);
+
+        var motionCaptor = ArgumentCaptor.forClass(Vector3dc.class);
+        verify(boat).addMotion(motionCaptor.capture());
+        assertTrue(motionCaptor.getValue().lengthSquared() > 0);
+    }
+
+    private EntityBoat mockBoat(Dimension dimension, List<EntityPlayer> passengers) {
+        var boat = mock(EntityBoat.class);
+        when(boat.getRuntimeId()).thenReturn(1L);
+        when(boat.hasEntityCollision()).thenReturn(true);
+        when(boat.getLocation()).thenReturn(new Location3d(1, 0, 0, dimension));
+        when(boat.getPushSpeedReduction()).thenReturn(1.0);
+        when(boat.getPassengers()).thenReturn(passengers);
+        return boat;
+    }
+
+    private static final class TestEntityPhysicsEngine extends AllayEntityPhysicsEngine {
+        private TestEntityPhysicsEngine(Dimension dimension) {
+            super(dimension);
+        }
+
+        private void setCollisions(Entity entity, Entity... collisions) {
+            entityCollisionCache.put(entity.getRuntimeId(), new ArrayList<>(List.of(collisions)));
+        }
+
+        private void applyEntityCollisionMotion(Entity entity) {
+            computeEntityCollisionMotion(entity);
+        }
+    }
+}


### PR DESCRIPTION
 Implements functional ordinary boats and bamboo rafts.

  - Adds placement and all vanilla boat variants
  - Adds buoyancy and server-authoritative movement
  - Adds two-player riding and dismounting
  - Synchronizes entity links and paddle metadata
  - Adds boat damage, destruction, and correct drops
  - Persists boat variants through NBT
  - Cleans up ride links during entity removal
  - Adds regression tests for variants, placement, passengers, movement, and buoyancy

  Chest boats, dispenser behavior, mob passengers, leashes, and bubble-column behavior are intentionally out of scope.
 
Related to https://github.com/AllayMC/Allay/issues/867 (item 12)