### PR TITLE
Chunk encoding cache

### DIFF
--- a/server/src/jmh/java/org/allaymc/server/SectionEncodeJMHTest.java
+++ b/server/src/jmh/java/org/allaymc/server/SectionEncodeJMHTest.java
@@ -1,0 +1,75 @@
+package org.allaymc.server;
+
+import org.allaymc.api.world.chunk.Chunk;
+import org.allaymc.api.world.dimension.DimensionTypes;
+import org.allaymc.server.world.chunk.AllayChunkSection;
+import org.allaymc.server.world.chunk.AllayUnsafeChunk;
+import org.allaymc.server.world.chunk.ChunkEncoder;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.allaymc.api.block.type.BlockTypes.STONE;
+
+/**
+ * @author GoobersAlley
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 3)
+@Threads(1)
+@Fork(1)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+public class SectionEncodeJMHTest {
+    private static final int SECTION_Y = 4;
+    private AllayUnsafeChunk chunk;
+    private Chunk safeChunk;
+    private AllayChunkSection section;
+
+    @Setup
+    public void init() {
+        Allay.initI18n();
+        Allay.initAllay();
+        chunk = AllayUnsafeChunk.builder().voidChunk(0, 0, DimensionTypes.OVERWORLD);
+        safeChunk = chunk.toSafeChunk();
+        for (int sectionY = 3; sectionY <= 5; sectionY++) {
+            for (int x = 0; x < 16; x++) {
+                for (int z = 0; z < 16; z++) {
+                    for (int i = 0; i < 4; i++) {
+                        safeChunk.setBlockState(x, sectionY * 16 + i, z, STONE.getDefaultState());
+                    }
+                }
+            }
+        }
+        section = chunk.getSection(SECTION_Y);
+    }
+
+    @Benchmark
+    public void encodeSectionUncached(Blackhole blackhole) {
+        blackhole.consume(ChunkEncoder.encodeSectionBlob(section));
+    }
+
+    @Benchmark
+    public void encodeSectionCachedHit(Blackhole blackhole) {
+        blackhole.consume(ChunkEncoder.encodeSectionBlob(chunk, SECTION_Y));
+    }
+
+    @Benchmark
+    public void encodeSectionCachedMiss(Blackhole blackhole) {
+        safeChunk.setBlockState(0, SECTION_Y * 16, 0, STONE.getDefaultState());
+        blackhole.consume(ChunkEncoder.encodeSectionBlob(chunk, SECTION_Y));
+    }
+
+    @Benchmark
+    public void encodeBiomesCachedHit(Blackhole blackhole) {
+        blackhole.consume(ChunkEncoder.encodeBiomesBlob(chunk));
+    }
+
+    @Benchmark
+    public void encodeSectionFullChunk(Blackhole blackhole) {
+        var buf = ChunkEncoder.writeToNetwork(chunk);
+        blackhole.consume(buf);
+        buf.release();
+    }
+}

--- a/server/src/main/java/org/allaymc/server/datastruct/palette/Palette.java
+++ b/server/src/main/java/org/allaymc/server/datastruct/palette/Palette.java
@@ -36,6 +36,27 @@ public final class Palette<V> {
     @Setter
     private boolean dirty;
 
+    private volatile long revision;
+    private volatile NetworkSnapshot networkSnapshot;
+
+    private record NetworkSnapshot(long revision, byte[] bytes) {}
+
+    public long revision() {
+        return revision;
+    }
+
+    public byte[] getCachedNetworkBytes() {
+        var snapshot = networkSnapshot;
+        if (snapshot != null && snapshot.revision == revision) {
+            return snapshot.bytes;
+        }
+        return null;
+    }
+
+    public void installNetworkSnapshot(byte[] bytes) {
+        networkSnapshot = new NetworkSnapshot(revision, bytes);
+    }
+
     public Palette(V first) {
         this(first, INITIAL_VERSION);
     }
@@ -87,6 +108,7 @@ public final class Palette<V> {
         var paletteIndex = this.paletteIndexFor(value);
         this.bitArray.set(index, paletteIndex);
         this.dirty = true;
+        this.revision++;
     }
 
     public void writeToNetwork(ByteBuf byteBuf, IntSerializer<V> serializer, Palette<V> last) {
@@ -116,6 +138,7 @@ public final class Palette<V> {
         }
 
         this.dirty = true;
+        this.revision++;
         if (hasCopyLastFlag(header)) {
             if (last == null) {
                 throw new PaletteException("Find copy last flag but last palette is null!");
@@ -172,6 +195,7 @@ public final class Palette<V> {
         }
 
         this.dirty = true;
+        this.revision++;
         this.palette.clear();
         var version = getVersionFromPaletteHeader(header);
         readWords(byteBuf, version);
@@ -216,6 +240,7 @@ public final class Palette<V> {
         }
 
         this.dirty = true;
+        this.revision++;
         if (hasCopyLastFlag(header)) {
             if (last == null) {
                 throw new PaletteException("Find copy last flag but last palette is null!");
@@ -277,6 +302,7 @@ public final class Palette<V> {
         palette.palette.clear();
         palette.palette.addAll(this.palette);
         palette.dirty = true;
+        palette.revision++;
     }
 
     public BitArrayVersion getVersion() {
@@ -308,6 +334,7 @@ public final class Palette<V> {
         this.palette = newPalette;
         this.bitArray = newbitArray;
         this.dirty = true;
+        this.revision++;
     }
 
     private void readWords(ByteBuf byteBuf, BitArrayVersion version) {
@@ -329,6 +356,7 @@ public final class Palette<V> {
 
         this.bitArray = newBitArray;
         this.dirty = true;
+        this.revision++;
     }
 
     private int paletteIndexFor(V value) {

--- a/server/src/main/java/org/allaymc/server/network/protocol/v766/PacketEncoder_v766.java
+++ b/server/src/main/java/org/allaymc/server/network/protocol/v766/PacketEncoder_v766.java
@@ -444,7 +444,8 @@ public class PacketEncoder_v766 extends PacketEncoder {
             byte[][] allBlobs = new byte[sectionCount + 1][];
             for (int i = 0; i < sectionCount; i++) {
                 allBlobs[i] = ChunkEncoder.encodeSectionBlob(
-                        chunk.getSection(dimensionType.minSectionY() + i)
+                        chunk,
+                        dimensionType.minSectionY() + i
                 );
             }
             allBlobs[sectionCount] = ChunkEncoder.encodeBiomesBlob(chunk);

--- a/server/src/main/java/org/allaymc/server/world/chunk/AllayUnsafeChunk.java
+++ b/server/src/main/java/org/allaymc/server/world/chunk/AllayUnsafeChunk.java
@@ -62,6 +62,7 @@ public class AllayUnsafeChunk implements UnsafeChunk {
     protected final Queue<WorldViewer.BlockUpdate> extraBlockUpdates;
     protected final Queue<Runnable> chunkTaskQueue;
     protected final AllayChunk safeChunk;
+    protected final ChunkEncoder.NetworkCache networkCache;
     @Getter
     @Setter
     protected volatile ChunkState state;
@@ -105,6 +106,7 @@ public class AllayUnsafeChunk implements UnsafeChunk {
         this.extraBlockUpdates = PlatformDependent.newMpscQueue();
         this.chunkTaskQueue = PlatformDependent.newMpscQueue();
         this.safeChunk = new AllayChunk(this);
+        this.networkCache = new ChunkEncoder.NetworkCache(sections.length);
     }
 
     public static AllayChunkBuilder builder() {
@@ -447,6 +449,10 @@ public class AllayUnsafeChunk implements UnsafeChunk {
     @Override
     public Chunk toSafeChunk() {
         return safeChunk;
+    }
+
+    ChunkEncoder.NetworkCache getNetworkCache() {
+        return networkCache;
     }
 
     public void sendBlockUpdates() {

--- a/server/src/main/java/org/allaymc/server/world/chunk/ChunkEncoder.java
+++ b/server/src/main/java/org/allaymc/server/world/chunk/ChunkEncoder.java
@@ -7,8 +7,11 @@ import io.netty.buffer.Unpooled;
 import lombok.extern.slf4j.Slf4j;
 import org.allaymc.api.block.type.BlockState;
 import org.allaymc.api.world.biome.BiomeType;
+import org.allaymc.server.datastruct.palette.IntSerializer;
 import org.allaymc.server.datastruct.palette.Palette;
 import org.cloudburstmc.nbt.NbtUtils;
+
+import java.util.Arrays;
 
 /**
  * @author daoge_cmd
@@ -53,7 +56,7 @@ public final class ChunkEncoder {
         byteBuf.writeByte(section.sectionY());
 
         for (var blockLayer : section.blockLayers()) {
-            blockLayer.writeToNetwork(byteBuf, BlockState::blockStateHash, null);
+            byteBuf.writeBytes(encodeLayerNetworkBytes(blockLayer, BlockState::blockStateHash));
         }
     }
 
@@ -72,10 +75,19 @@ public final class ChunkEncoder {
         }
     }
 
+    public static byte[] encodeSectionBlob(AllayUnsafeChunk chunk, int sectionY) {
+        var section = chunk.getSection(sectionY);
+        return chunk.getNetworkCache().sectionBlob(section, sectionY - chunk.getDimensionType().minSectionY());
+    }
+
     /**
      * Encode biomes as byte[] blob (PURE biomes only, NO border block count).
      */
     public static byte[] encodeBiomesBlob(AllayUnsafeChunk chunk) {
+        return chunk.getNetworkCache().biomesBlob(chunk);
+    }
+
+    private static byte[] encodeBiomesBlobUncached(AllayUnsafeChunk chunk) {
         var byteBuf = ByteBufAllocator.DEFAULT.ioBuffer();
         try {
             writeBiomes(chunk, byteBuf);
@@ -113,12 +125,9 @@ public final class ChunkEncoder {
     }
 
     static void writeBiomes(AllayUnsafeChunk chunk, ByteBuf byteBuf) {
-        Palette<BiomeType> last = null;
         for (var s : chunk.getSections()) {
             var section = (AllayChunkSection) s;
-            section.biomes().writeToNetwork(byteBuf, BiomeType::getId, last);
-            // TODO: fix copy last flag
-            // last = section.biomes();
+            byteBuf.writeBytes(encodeLayerNetworkBytes(section.biomes(), BiomeType::getId));
         }
     }
 
@@ -131,6 +140,99 @@ public final class ChunkEncoder {
                 }
             } catch (Throwable t) {
                 log.error("Error while encoding block entities in chunk {}, {}", chunk.getX(), chunk.getZ(), t);
+            }
+        }
+    }
+
+    private static <V> byte[] encodeLayerNetworkBytes(Palette<V> palette, IntSerializer<V> serializer) {
+        byte[] cached = palette.getCachedNetworkBytes();
+        if (cached != null) {
+            return cached;
+        }
+        var byteBuf = ByteBufAllocator.DEFAULT.ioBuffer();
+        byte[] bytes;
+        try {
+            palette.writeToNetwork(byteBuf, serializer, null);
+            bytes = new byte[byteBuf.readableBytes()];
+            byteBuf.readBytes(bytes);
+        } finally {
+            byteBuf.release();
+        }
+        palette.installNetworkSnapshot(bytes);
+        return bytes;
+    }
+
+    static final class NetworkCache {
+        private final Object lock = new Object();
+        private final SectionEntry[] sections;
+        private BiomesEntry biomes;
+
+        NetworkCache(int sectionCount) {
+            this.sections = new SectionEntry[sectionCount];
+        }
+
+        byte[] sectionBlob(AllayChunkSection section, int index) {
+            synchronized (lock) {
+                var entry = sections[index];
+                long layer0Revision = section.blockLayers()[0].revision();
+                long layer1Revision = section.blockLayers()[1].revision();
+                if (entry != null && entry.layer0Revision == layer0Revision && entry.layer1Revision == layer1Revision) {
+                    return entry.blob;
+                }
+                byte[] blob = ChunkEncoder.encodeSectionBlob(section);
+                sections[index] = new SectionEntry(layer0Revision, layer1Revision, blob);
+                return blob;
+            }
+        }
+
+        byte[] biomesBlob(AllayUnsafeChunk chunk) {
+            synchronized (lock) {
+                var chunkSections = chunk.getSections();
+                int count = chunkSections.size();
+                long[] revisions = new long[count];
+                for (int i = 0; i < count; i++) {
+                    revisions[i] = ((AllayChunkSection) chunkSections.get(i)).biomes().revision();
+                }
+                if (biomes != null && Arrays.equals(biomes.revisions, revisions)) {
+                    return biomes.blob;
+                }
+                byte[] blob = ChunkEncoder.encodeBiomesBlobUncached(chunk);
+                biomes = new BiomesEntry(revisions, blob);
+                return blob;
+            }
+        }
+
+        int cachedSectionEntryCount() {
+            synchronized (lock) {
+                int count = 0;
+                for (var entry : sections) {
+                    if (entry != null) {
+                        count++;
+                    }
+                }
+                return count;
+            }
+        }
+
+        static final class SectionEntry {
+            final long layer0Revision;
+            final long layer1Revision;
+            final byte[] blob;
+
+            SectionEntry(long layer0Revision, long layer1Revision, byte[] blob) {
+                this.layer0Revision = layer0Revision;
+                this.layer1Revision = layer1Revision;
+                this.blob = blob;
+            }
+        }
+
+        static final class BiomesEntry {
+            final long[] revisions;
+            final byte[] blob;
+
+            BiomesEntry(long[] revisions, byte[] blob) {
+                this.revisions = revisions;
+                this.blob = blob;
             }
         }
     }

--- a/server/src/main/java/org/allaymc/server/world/storage/leveldb/AllayLevelDBWorldStorage.java
+++ b/server/src/main/java/org/allaymc/server/world/storage/leveldb/AllayLevelDBWorldStorage.java
@@ -41,6 +41,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -73,6 +74,7 @@ public class AllayLevelDBWorldStorage implements WorldStorage {
     // Guards batchMode, batchChunks, and batchEntityRequests to make check-then-enqueue atomic.
     private final Lock batchLock;
     private boolean batchMode;
+    private final Map<EntityWriteKey, CompletableFuture<Void>> entityWriteChains = new ConcurrentHashMap<>();
 
     private World world;
 
@@ -346,6 +348,14 @@ public class AllayLevelDBWorldStorage implements WorldStorage {
     }
 
     private void addEntitiesToBatch(int chunkX, int chunkZ, DimensionType dimensionType, Map<Long, Entity> entities, WriteBatch writeBatch) {
+        var entityNbt = new Long2ObjectOpenHashMap<NbtMap>();
+        for (var entry : entities.entrySet()) {
+            entityNbt.put(entry.getKey(), entry.getValue().saveNBT());
+        }
+        addEntityNbtToBatch(chunkX, chunkZ, dimensionType, entityNbt, writeBatch);
+    }
+
+    private void addEntityNbtToBatch(int chunkX, int chunkZ, DimensionType dimensionType, Map<Long, NbtMap> entityNbt, WriteBatch writeBatch) {
         var idsBuf = ByteBufAllocator.DEFAULT.buffer();
         try {
             var idsKey = LevelDBKey.createEntityIdsKey(chunkX, chunkZ, dimensionType);
@@ -360,9 +370,9 @@ public class AllayLevelDBWorldStorage implements WorldStorage {
             }
 
             // Write new entities
-            for (var entry : entities.entrySet()) {
+            for (var entry : entityNbt.entrySet()) {
                 idsBuf.writeLongLE(entry.getKey());
-                writeBatch.put(LevelDBKey.indexEntity(entry.getKey()), AllayNBTUtils.nbtToBytesLE(entry.getValue().saveNBT()));
+                writeBatch.put(LevelDBKey.indexEntity(entry.getKey()), AllayNBTUtils.nbtToBytesLE(entry.getValue()));
             }
 
             writeBatch.put(idsKey, ByteBufUtil.getBytes(idsBuf));
@@ -437,47 +447,43 @@ public class AllayLevelDBWorldStorage implements WorldStorage {
     }
 
     protected CompletableFuture<Void> writeEntities0(int chunkX, int chunkZ, DimensionType dimensionType, Map<Long, Entity> entities, boolean asyncWrite) {
-        var idsBuf = ByteBufAllocator.DEFAULT.buffer();
+        var entityNbt = new Long2ObjectOpenHashMap<NbtMap>();
+        for (var entry : entities.entrySet()) {
+            entityNbt.put(entry.getKey(), entry.getValue().saveNBT());
+        }
+        if (asyncWrite) {
+            return submitEntityWrite(chunkX, chunkZ, dimensionType, entityNbt);
+        }
         try (var writeBatch = this.db.createWriteBatch()) {
-            var idsKey = LevelDBKey.createEntityIdsKey(chunkX, chunkZ, dimensionType);
-
-            // Delete the old entities in this chunk
-            var oldIds = this.db.get(idsKey);
-            if (oldIds != null) {
-                var oldIdsBuf = Unpooled.wrappedBuffer(oldIds);
-                for (var i = 0; i < oldIds.length; i += Long.BYTES) {
-                    writeBatch.delete(LevelDBKey.indexEntity(oldIdsBuf.readLongLE()));
-                }
-            }
-
-            // Write the new entities
-            for (var entry : entities.entrySet()) {
-                var entity = entry.getValue();
-                idsBuf.writeLongLE(entry.getKey());
-                writeBatch.put(LevelDBKey.indexEntity(entry.getKey()), AllayNBTUtils.nbtToBytesLE(entity.saveNBT()));
-            }
-
-            writeBatch.put(idsKey, ByteBufUtil.getBytes(idsBuf));
-            return handleEntitiesWriteBatch(chunkX, chunkZ, writeBatch, asyncWrite);
+            addEntityNbtToBatch(chunkX, chunkZ, dimensionType, entityNbt, writeBatch);
+            this.db.write(writeBatch);
         } catch (IOException e) {
             throw new WorldStorageException(e);
-        } finally {
-            idsBuf.release();
         }
+        return CompletableFuture.completedFuture(null);
     }
 
-    protected CompletableFuture<Void> handleEntitiesWriteBatch(int chunkX, int chunkZ, WriteBatch writeBatch, boolean asyncWrite) {
-        if (asyncWrite) {
-            return CompletableFuture
-                    .runAsync(() -> this.db.write(writeBatch), Server.getInstance().getVirtualThreadPool())
-                    .exceptionally(t -> {
-                        log.error("Failed to write entities in chunk ({}, {})", chunkX, chunkZ, t);
-                        return null;
-                    });
-        }
+    private CompletableFuture<Void> submitEntityWrite(int chunkX, int chunkZ, DimensionType dimensionType, Map<Long, NbtMap> entityNbt) {
+        var key = new EntityWriteKey(chunkX, chunkZ, dimensionType.getId());
+        return entityWriteChains.compute(key, (k, previous) -> {
+            CompletableFuture<Void> next;
+            if (previous == null) {
+                next = CompletableFuture.runAsync(() -> writeEntitiesAsync(chunkX, chunkZ, dimensionType, entityNbt), Server.getInstance().getVirtualThreadPool());
+            } else {
+                next = previous.handle((v, t) -> null).thenRunAsync(() -> writeEntitiesAsync(chunkX, chunkZ, dimensionType, entityNbt), Server.getInstance().getVirtualThreadPool());
+            }
+            next.whenComplete((v, t) -> entityWriteChains.remove(key, next));
+            return next;
+        });
+    }
 
-        this.db.write(writeBatch);
-        return CompletableFuture.completedFuture(null);
+    private void writeEntitiesAsync(int chunkX, int chunkZ, DimensionType dimensionType, Map<Long, NbtMap> entityNbt) {
+        try (var writeBatch = this.db.createWriteBatch()) {
+            addEntityNbtToBatch(chunkX, chunkZ, dimensionType, entityNbt, writeBatch);
+            this.db.write(writeBatch);
+        } catch (Throwable e) {
+            log.error("Failed to write entities in chunk ({}, {})", chunkX, chunkZ, e);
+        }
     }
 
     @Override

--- a/server/src/test/java/org/allaymc/server/world/chunk/ChunkEncoderCacheTest.java
+++ b/server/src/test/java/org/allaymc/server/world/chunk/ChunkEncoderCacheTest.java
@@ -1,0 +1,78 @@
+package org.allaymc.server.world.chunk;
+
+import org.allaymc.api.world.biome.BiomeTypes;
+import org.allaymc.api.world.dimension.DimensionTypes;
+import org.allaymc.testutils.AllayTestExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Arrays;
+
+import static org.allaymc.api.block.type.BlockTypes.AIR;
+import static org.allaymc.api.block.type.BlockTypes.STONE;
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(AllayTestExtension.class)
+class ChunkEncoderCacheTest {
+
+    @Test
+    void testUnchangedSectionReturnsCachedBlob() {
+        var chunk = AllayUnsafeChunk.builder().voidChunk(0, 0, DimensionTypes.OVERWORLD);
+        byte[] first = ChunkEncoder.encodeSectionBlob(chunk, 0);
+        byte[] second = ChunkEncoder.encodeSectionBlob(chunk, 0);
+        assertSame(first, second);
+        assertArrayEquals(first, ChunkEncoder.encodeSectionBlob(chunk.getSection(0)));
+    }
+
+    @Test
+    void testSetBlockStateInvalidatesSectionBlob() {
+        var chunk = AllayUnsafeChunk.builder().voidChunk(0, 0, DimensionTypes.OVERWORLD);
+        byte[] before = ChunkEncoder.encodeSectionBlob(chunk, 0);
+        chunk.setBlockState(0, 0, 0, STONE.getDefaultState(), 0, false);
+        byte[] after = ChunkEncoder.encodeSectionBlob(chunk, 0);
+        assertNotSame(before, after);
+        assertFalse(Arrays.equals(before, after));
+    }
+
+    @Test
+    void testBiomesBlobCachedAndInvalidated() {
+        var chunk = AllayUnsafeChunk.builder().voidChunk(0, 0, DimensionTypes.OVERWORLD);
+        byte[] first = ChunkEncoder.encodeBiomesBlob(chunk);
+        byte[] second = ChunkEncoder.encodeBiomesBlob(chunk);
+        assertSame(first, second);
+        chunk.setBiome(0, 0, 0, BiomeTypes.CHERRY_GROVE);
+        byte[] third = ChunkEncoder.encodeBiomesBlob(chunk);
+        assertNotSame(second, third);
+        assertFalse(Arrays.equals(second, third));
+    }
+
+    @Test
+    void testCacheRespectsSizeBound() {
+        var chunk = AllayUnsafeChunk.builder().voidChunk(0, 0, DimensionTypes.OVERWORLD);
+        var cache = chunk.getNetworkCache();
+        int sectionCount = chunk.getDimensionType().chunkSectionCount();
+        int minSectionY = chunk.getDimensionType().minSectionY();
+        for (int i = 0; i < sectionCount; i++) {
+            ChunkEncoder.encodeSectionBlob(chunk, minSectionY + i);
+        }
+        assertEquals(sectionCount, cache.cachedSectionEntryCount());
+        chunk.setBlockState(0, 0, 0, STONE.getDefaultState(), 0, false);
+        ChunkEncoder.encodeSectionBlob(chunk, 0);
+        assertEquals(sectionCount, cache.cachedSectionEntryCount());
+    }
+
+    @Test
+    void testPaletteSnapshotSingleSlot() {
+        var section = new AllayChunkSection((byte) 0);
+        var layer0 = section.blockLayers()[0];
+        assertNull(layer0.getCachedNetworkBytes());
+        byte[] blob1 = ChunkEncoder.encodeSectionBlob(section);
+        byte[] cached = layer0.getCachedNetworkBytes();
+        assertNotNull(cached);
+        assertSame(cached, layer0.getCachedNetworkBytes());
+        section.setBlockState(0, 0, 0, STONE.getDefaultState(), 0);
+        assertNull(layer0.getCachedNetworkBytes());
+        byte[] blob2 = ChunkEncoder.encodeSectionBlob(section);
+        assertFalse(Arrays.equals(blob1, blob2));
+    }
+}


### PR DESCRIPTION
stop reencoding the same chunk for every player 
Ecode once, reuse it, and don't let saving lag the server.

PREF fix (PR 2/9)